### PR TITLE
fix: remove duplicate title from runbook blog post

### DIFF
--- a/src/content/blog/2026-02-01-por-que-usar-runbook.md
+++ b/src/content/blog/2026-02-01-por-que-usar-runbook.md
@@ -11,8 +11,6 @@ author:
 date: 2026-02-01
 ---
 
-# Por qué usar Runbooks: Automatiza la documentación de escenarios reproducibles con IA
-
 ## Overview
 
 Con este artículo quiero que desde ahora el crear runbooks sea un ritual natural que sea parte de tu flujo de trabajo, ya sea que seas parte del equipo de QA, Dev, DevOps, análisis de datos, etc. La creación de runbooks debería ser una práctica natural y recurrente para ti, y no solo una tarea en el tablero que deba ser solicitada por alguien más.


### PR DESCRIPTION
The title was appearing twice on the page because it was defined both
in the frontmatter and as an h1 heading in the markdown content. The
blog layout already renders the frontmatter title.

https://claude.ai/code/session_01Db1Ubn6dpPaa2e7vGzbBVW