### PR TITLE
Add /pay and /fintoc redirect pages to FINTOC_URL

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -1,5 +1,6 @@
 type ENV = {
   BLOG_POSTS_VISITS: KVNamespace;
+  FINTOC_URL?: string;
 };
 
 declare namespace App {

--- a/src/pages/fintoc.astro
+++ b/src/pages/fintoc.astro
@@ -1,0 +1,4 @@
+---
+const url = Astro.locals.runtime?.env?.FINTOC_URL ?? "https://fintoc.me/jondotsoy";
+return Astro.redirect(url, 302);
+---

--- a/src/pages/pay.astro
+++ b/src/pages/pay.astro
@@ -1,0 +1,4 @@
+---
+const url = Astro.locals.runtime?.env?.FINTOC_URL ?? "https://fintoc.me/jondotsoy";
+return Astro.redirect(url, 302);
+---


### PR DESCRIPTION
Both routes do a 302 (non-permanent) redirect to the URL configured
via the FINTOC_URL environment variable, defaulting to https://fintoc.me/jondotsoy.

https://claude.ai/code/session_015TMykGSB5q2sfxcjZsxoQ1