### PR TITLE
Add interactive demo page for the my-state pattern

### DIFF
--- a/src/components/my-state-pattern/MyStateDemo.tsx
+++ b/src/components/my-state-pattern/MyStateDemo.tsx
@@ -33,12 +33,31 @@ const RESOURCE_DEFS: ResourceDef[] = [
   { key: "serverHealth", sample: { status: "ok", latencyMs: 42 } },
 ];
 
-function simulate(def: ResourceDef, config: Config): Promise<unknown> {
+// Simula fetch(url, { signal }): si el signal aborta antes de que el
+// timer dispare, rechaza con un AbortError real y limpia el timer, igual
+// que haría el navegador con una petición de red cancelada de verdad.
+function simulate(
+  def: ResourceDef,
+  config: Config,
+  signal: AbortSignal,
+): Promise<unknown> {
   return new Promise((resolve, reject) => {
-    setTimeout(() => {
+    if (signal.aborted) {
+      reject(new DOMException("Aborted", "AbortError"));
+      return;
+    }
+    const timer = setTimeout(() => {
       if (config.forceError) reject(new Error(`No se pudo obtener ${def.key}`));
       else resolve(def.sample);
     }, config.delayMs);
+    signal.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timer);
+        reject(new DOMException("Aborted", "AbortError"));
+      },
+      { once: true },
+    );
   });
 }
 
@@ -46,27 +65,46 @@ function createDemoStore(
   def: ResourceDef,
   config: Config,
   log: (text: string) => void,
-): WritableAtom<Resource<unknown>> {
+): { $resource: WritableAtom<Resource<unknown>>; retry: () => void } {
   const $resource = atom<Resource<unknown>>([true, null, null]);
+  let controller: AbortController | null = null;
 
-  onMount($resource, () => {
-    let cancelled = false;
-    log(`[$${def.key}] onMount → nadie escuchaba, ahora sí: fetch()`);
+  // Un único punto de entrada para disparar el fetch, usado tanto por
+  // onMount como por el botón "Reintentar": aborta cualquier petición
+  // anterior antes de empezar una nueva, así nunca hay dos en carrera.
+  function run(reason: string) {
+    controller?.abort();
+    const ownController = new AbortController();
+    controller = ownController;
+    const { signal } = ownController;
+
+    log(`[$${def.key}] ${reason}`);
     $resource.set([true, null, null]);
 
-    t(simulate(def, config)).then(([ok, error, data]) => {
-      if (cancelled) return;
+    t(simulate(def, config, signal)).then(([ok, error, data]) => {
+      if (signal.aborted) {
+        log(`[$${def.key}] fetch abortado, se descarta la respuesta`);
+        return;
+      }
       $resource.set([false, error, data as unknown]);
       log(`[$${def.key}] t() resolvió → ok:${ok}`);
     });
+  }
 
+  onMount($resource, () => {
+    run("onMount → nadie escuchaba, ahora sí: fetch()");
+
+    // Esto es el "onUnmount": nanostores llama esta función cuando el
+    // último subscriptor se va (con ~1s de gracia para evitar abortar
+    // por un remount rápido). Es el lugar correcto para cancelar
+    // cualquier petición en curso vía AbortController.
     return () => {
-      cancelled = true;
-      log(`[$${def.key}] onStop → último subscriptor se fue, limpiando`);
+      log(`[$${def.key}] onStop → controller.abort() del fetch en curso`);
+      controller?.abort();
     };
   });
 
-  return $resource;
+  return { $resource, retry: () => run("reintento manual") };
 }
 
 // Reading `store.get()` on a nanostores atom momentarily mounts it (even
@@ -118,13 +156,13 @@ function ResourceCard({
   store,
   config,
   active,
-  log,
+  onRetry,
 }: {
   def: ResourceDef;
   store: WritableAtom<Resource<unknown>>;
   config: Config;
   active: boolean;
-  log: (text: string) => void;
+  onRetry: () => void;
 }) {
   const state = useGatedValue<Resource<unknown>>(store, active, [
     true,
@@ -163,14 +201,7 @@ function ResourceCard({
           forzar error
         </label>
         <button
-          onClick={() => {
-            store.set([true, null, null]);
-            log(`[$${def.key}] reintento manual`);
-            t(simulate(def, config)).then(([ok, error, data]) => {
-              store.set([false, error, data as unknown]);
-              log(`[$${def.key}] t() resolvió → ok:${ok}`);
-            });
-          }}
+          onClick={onRetry}
           disabled={!active}
           className="rounded-md border border-stone-300 bg-white px-2.5 py-1 font-medium text-stone-700 transition-colors hover:bg-stone-100 disabled:cursor-not-allowed disabled:opacity-40"
         >
@@ -200,20 +231,27 @@ export default function MyStateDemo() {
     ]);
   };
 
-  const { stores, configs, $home } = useMemo(() => {
+  const { stores, retries, configs, $home } = useMemo(() => {
     const configs: Record<string, Config> = {};
     const stores: Record<string, WritableAtom<Resource<unknown>>> = {};
+    const retries: Record<string, () => void> = {};
     for (const def of RESOURCE_DEFS) {
-      const config: Config = { forceError: false, delayMs: 900 };
+      // nanostores espera ~1s (STORE_UNMOUNT_DELAY) tras el último
+      // unsubscribe antes de llamar el onUnmount; el delay simulado debe
+      // ser mayor a eso para que desmontar durante la carga demuestre un
+      // abort real y no una simple carrera ganada por el fetch.
+      const config: Config = { forceError: false, delayMs: 2200 };
       configs[def.key] = config;
-      stores[def.key] = createDemoStore(def, config, pushLog);
+      const demoStore = createDemoStore(def, config, pushLog);
+      stores[def.key] = demoStore.$resource;
+      retries[def.key] = demoStore.retry;
     }
     const $home = computed(
       RESOURCE_DEFS.map((d) => stores[d.key]),
       (...states) =>
         Object.fromEntries(RESOURCE_DEFS.map((d, i) => [d.key, states[i]])),
     );
-    return { stores, configs, $home };
+    return { stores, retries, configs, $home };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [generation]);
 
@@ -287,7 +325,7 @@ export default function MyStateDemo() {
             store={stores[def.key]}
             config={configs[def.key]}
             active={active}
-            log={pushLog}
+            onRetry={retries[def.key]}
           />
         ))}
       </div>

--- a/src/components/my-state-pattern/MyStateDemo.tsx
+++ b/src/components/my-state-pattern/MyStateDemo.tsx
@@ -107,6 +107,67 @@ function createDemoStore(
   return { $resource, retry: () => run("reintento manual") };
 }
 
+type SseTick = { tick: number; value: number };
+
+// Simula un EventSource: en vez de resolver una vez, empuja mensajes
+// periódicos al store mientras está "conectado". onUnmount cierra la
+// conexión (clearInterval aquí, `source.close()` con un EventSource real)
+// en vez de abortar una petición puntual — mismo contrato, otro recurso.
+function createSseDemoStore(log: (text: string) => void): {
+  $resource: WritableAtom<Resource<SseTick>>;
+  config: Config;
+  reconnect: () => void;
+} {
+  const $resource = atom<Resource<SseTick>>([true, null, null]);
+  const config: Config = { forceError: false, delayMs: 700 };
+  let timer: ReturnType<typeof setInterval> | null = null;
+
+  function close() {
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+  }
+
+  function connect(reason: string) {
+    close();
+    log(`[$liveMetrics] ${reason}`);
+    $resource.set([true, null, null]);
+
+    let tick = 0;
+    timer = setInterval(() => {
+      if (config.forceError) {
+        log("[$liveMetrics] conexión perdida (source.onerror)");
+        $resource.set([false, new Error("Conexión SSE perdida"), null]);
+        close();
+        return;
+      }
+      tick += 1;
+      if (tick === 1) log("[$liveMetrics] primer mensaje (source.onmessage)");
+      $resource.set([
+        false,
+        null,
+        { tick, value: Math.round(Math.random() * 100) },
+      ]);
+    }, config.delayMs);
+  }
+
+  onMount($resource, () => {
+    connect("onMount → abre EventSource");
+
+    return () => {
+      log("[$liveMetrics] onStop → source.close()");
+      close();
+    };
+  });
+
+  return {
+    $resource,
+    config,
+    reconnect: () => connect("reconectar (nuevo EventSource)"),
+  };
+}
+
 // Reading `store.get()` on a nanostores atom momentarily mounts it (even
 // without a lasting listener), which would trigger onMount's fetch as a
 // side effect of rendering. To keep "nobody is watching" truly inert
@@ -212,6 +273,76 @@ function ResourceCard({
   );
 }
 
+function SseCard({
+  store,
+  config,
+  active,
+  onReconnect,
+}: {
+  store: WritableAtom<Resource<SseTick>>;
+  config: Config;
+  active: boolean;
+  onReconnect: () => void;
+}) {
+  const state = useGatedValue<Resource<SseTick>>(store, active, [
+    true,
+    null,
+    null,
+  ]);
+  const [loading, error, data] = state;
+  const [forceError, setForceError] = useState(config.forceError);
+
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border border-stone-200 bg-white p-4">
+      <div className="flex items-center justify-between">
+        <code className="text-sm font-semibold text-stone-800">
+          $liveMetrics
+        </code>
+        {loading ? (
+          <StatusPill state={state} />
+        ) : error ? (
+          <StatusPill state={state} />
+        ) : (
+          <span className="inline-flex items-center gap-1.5 rounded-full bg-sky-100 px-2.5 py-0.5 text-xs font-medium text-sky-800">
+            <span className="size-1.5 animate-pulse rounded-full bg-sky-500" />
+            streaming
+          </span>
+        )}
+      </div>
+
+      <pre className="overflow-x-auto rounded-md bg-stone-50 p-2 text-[11px] leading-relaxed text-stone-700">
+        {`[${state[0]}, ${
+          error
+            ? JSON.stringify(String((error as Error)?.message ?? error))
+            : "null"
+        }, ${data ? JSON.stringify(data) : "null"}]`}
+      </pre>
+
+      <div className="flex items-center justify-between gap-2 text-xs">
+        <label className="flex items-center gap-1.5 text-stone-600">
+          <input
+            type="checkbox"
+            checked={forceError}
+            onChange={() => {
+              config.forceError = !config.forceError;
+              setForceError(config.forceError);
+            }}
+            className="size-3.5"
+          />
+          simular corte
+        </label>
+        <button
+          onClick={onReconnect}
+          disabled={!active}
+          className="rounded-md border border-stone-300 bg-white px-2.5 py-1 font-medium text-stone-700 transition-colors hover:bg-stone-100 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          Reconectar
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export default function MyStateDemo() {
   const [active, setActive] = useState(false);
   const [log, setLog] = useState<Entry[]>([]);
@@ -231,7 +362,7 @@ export default function MyStateDemo() {
     ]);
   };
 
-  const { stores, retries, configs, $home } = useMemo(() => {
+  const { stores, retries, configs, $home, sse } = useMemo(() => {
     const configs: Record<string, Config> = {};
     const stores: Record<string, WritableAtom<Resource<unknown>>> = {};
     const retries: Record<string, () => void> = {};
@@ -251,7 +382,10 @@ export default function MyStateDemo() {
       (...states) =>
         Object.fromEntries(RESOURCE_DEFS.map((d, i) => [d.key, states[i]])),
     );
-    return { stores, retries, configs, $home };
+    // $liveMetrics no entra a $home: no es un recurso de una sola
+    // resolución, pero comparte el mismo contrato onMount/onUnmount.
+    const sse = createSseDemoStore(pushLog);
+    return { stores, retries, configs, $home, sse };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [generation]);
 
@@ -328,6 +462,22 @@ export default function MyStateDemo() {
             onRetry={retries[def.key]}
           />
         ))}
+      </div>
+
+      <div>
+        <p className="mb-1 text-xs font-medium text-stone-500">
+          Streaming (SSE): mismo ciclo <code>onMount</code>/
+          <code>onUnmount</code>, un recurso que no se resuelve una sola vez
+        </p>
+        <div className="grid gap-4 sm:grid-cols-3">
+          <SseCard
+            key={`sse-${generation}`}
+            store={sse.$resource}
+            config={sse.config}
+            active={active}
+            onReconnect={sse.reconnect}
+          />
+        </div>
       </div>
 
       <div>

--- a/src/components/my-state-pattern/MyStateDemo.tsx
+++ b/src/components/my-state-pattern/MyStateDemo.tsx
@@ -578,7 +578,7 @@ function ResourceCard({ def }: { def: ResourceDef }) {
   };
 
   return (
-    <div className="flex flex-col gap-3 rounded-lg border border-stone-200 bg-white p-4">
+    <div className="flex min-w-0 flex-col gap-3 rounded-lg border border-stone-200 bg-white p-4">
       <div className="flex items-center justify-between">
         <code className="text-sm font-semibold text-stone-800">${def.key}</code>
         <StatusPill state={state} />
@@ -676,7 +676,7 @@ function SseCard() {
   };
 
   return (
-    <div className="flex flex-col gap-3 rounded-lg border border-stone-200 bg-white p-4">
+    <div className="flex min-w-0 flex-col gap-3 rounded-lg border border-stone-200 bg-white p-4">
       <div className="flex items-center justify-between">
         <code className="text-sm font-semibold text-stone-800">
           $liveMetrics
@@ -804,7 +804,7 @@ function FeedCard() {
   }, [active, state.hasMore, state.loading, loadMore]);
 
   return (
-    <div className="flex flex-col gap-3 rounded-lg border border-stone-200 bg-white p-4">
+    <div className="flex min-w-0 flex-col gap-3 rounded-lg border border-stone-200 bg-white p-4">
       <div className="flex items-center justify-between">
         <code className="text-sm font-semibold text-stone-800">$feed</code>
         {state.error ? (
@@ -909,16 +909,16 @@ function ImageParamsCard() {
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   return (
-    <div className="flex flex-col gap-3 rounded-lg border border-stone-200 bg-white p-4 sm:flex-row">
+    <div className="flex min-w-0 flex-col gap-3 rounded-lg border border-stone-200 bg-white p-4 sm:flex-row">
       <img
         src={imageUrl}
         alt={params.text || "placeholder"}
         width={params.width}
         height={params.height}
-        className="h-auto w-full max-w-[200px] rounded-md border border-stone-100 sm:w-1/2"
+        className="h-auto w-full max-w-[200px] shrink-0 rounded-md border border-stone-100 sm:w-1/2"
       />
 
-      <div className="flex flex-1 flex-col gap-3">
+      <div className="flex min-w-0 flex-1 flex-col gap-3">
         <div className="flex items-center justify-between">
           <code className="text-sm font-semibold text-stone-800">
             $imageUrl
@@ -1003,7 +1003,7 @@ function SearchCard() {
   };
 
   return (
-    <div className="flex flex-col gap-3 rounded-lg border border-stone-200 bg-white p-4">
+    <div className="flex min-w-0 flex-col gap-3 rounded-lg border border-stone-200 bg-white p-4">
       <div className="flex items-center justify-between">
         <code className="text-sm font-semibold text-stone-800">$search</code>
         <StatusPill state={[loading, error, data]} />

--- a/src/components/my-state-pattern/MyStateDemo.tsx
+++ b/src/components/my-state-pattern/MyStateDemo.tsx
@@ -347,6 +347,99 @@ function createImageParamsStore(): {
   return { $params, $imageUrl };
 }
 
+type SearchItem = { id: number; title: string };
+
+const SEARCH_CATALOG: SearchItem[] = [
+  { id: 1, title: "my-state pattern" },
+  { id: 2, title: "nanostores" },
+  { id: 3, title: "onMount / onUnmount" },
+  { id: 4, title: "AbortController" },
+  { id: 5, title: "EventSource (SSE)" },
+  { id: 6, title: "computed" },
+  { id: 7, title: "infinite scroll" },
+  { id: 8, title: "cursor de paginación" },
+];
+
+// Simula un endpoint de búsqueda: filtra el catálogo local tras un delay,
+// y respeta cancelación real vía AbortSignal, igual que un fetch de verdad.
+function simulateSearch(
+  query: string,
+  signal: AbortSignal,
+): Promise<SearchItem[]> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new DOMException("Aborted", "AbortError"));
+      return;
+    }
+    const timer = setTimeout(() => {
+      const q = query.trim().toLowerCase();
+      resolve(
+        q
+          ? SEARCH_CATALOG.filter((item) =>
+              item.title.toLowerCase().includes(q),
+            )
+          : SEARCH_CATALOG,
+      );
+    }, 500);
+    signal.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timer);
+        reject(new DOMException("Aborted", "AbortError"));
+      },
+      { once: true },
+    );
+  });
+}
+
+// Variante de "parámetros reactivos" que sí pide algo remoto: dos stores
+// separados. $params guarda lo que el usuario escribe, sin lógica propia.
+// $search es el que tiene onMount: al montarse, se subscribe a $params y
+// dispara el fetch correspondiente — y vuelve a hacerlo cada vez que
+// $params cambia, cancelando el fetch anterior primero.
+function createSearchStore(log: (text: string) => void): {
+  $params: WritableAtom<string>;
+  $search: WritableAtom<Resource<SearchItem[]>>;
+} {
+  const $params = atom<string>("");
+  const $search = atom<Resource<SearchItem[]>>([true, null, null]);
+  let controller: AbortController | null = null;
+
+  onMount($search, () => {
+    log("onMount → subscribe a $params");
+
+    // subscribe (a diferencia de listen) dispara también con el valor
+    // ACTUAL de $params, así el primer fetch sale de inmediato al montar,
+    // igual que cualquier otro recurso de la página — y sigue disparando
+    // con cada cambio posterior.
+    const unsubscribe = $params.subscribe((query) => {
+      controller?.abort();
+      const ownController = new AbortController();
+      controller = ownController;
+      $search.set([true, null, null]);
+
+      t(simulateSearch(query, ownController.signal)).then(
+        ([ok, error, data]) => {
+          if (ownController.signal.aborted) {
+            log("fetch abortado (cambió $params antes de resolver)");
+            return;
+          }
+          $search.set(ok ? [false, null, data] : [false, error, null]);
+          log(`t() resolvió → ok:${ok}`);
+        },
+      );
+    });
+
+    return () => {
+      log("onStop → unsubscribe de $params, aborta el fetch en curso");
+      unsubscribe();
+      controller?.abort();
+    };
+  });
+
+  return { $params, $search };
+}
+
 // A diferencia de useGatedValue, este store no tiene onMount ni efectos
 // secundarios que activar: leer .get() en cualquier momento es inofensivo,
 // así que basta con un subscribe normal (lo mismo que hace useStore de
@@ -876,6 +969,107 @@ function ImageParamsCard() {
   );
 }
 
+function SearchCard() {
+  const [active, setActive] = useState(false);
+  const { log, push, logRef } = useCardLog();
+
+  const { $params, $search } = useMemo(
+    () => createSearchStore(push),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+  const [loading, error, data] = useGatedValue<Resource<SearchItem[]>>(
+    $search,
+    active,
+    [true, null, null],
+  );
+  const [text, setText] = useState("");
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleToggle = () => {
+    setActive((prev) => {
+      const next = !prev;
+      push(
+        next
+          ? "subscribe() → primer subscriptor, se activa onMount"
+          : "unsubscribe → sin subscriptores, se agenda onStop",
+      );
+      return next;
+    });
+  };
+
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border border-stone-200 bg-white p-4">
+      <div className="flex items-center justify-between">
+        <code className="text-sm font-semibold text-stone-800">$search</code>
+        <StatusPill state={[loading, error, data]} />
+      </div>
+
+      <button
+        onClick={handleToggle}
+        className={
+          "rounded-md px-2.5 py-1 text-xs font-semibold transition-colors " +
+          (active
+            ? "bg-stone-900 text-white hover:bg-stone-700"
+            : "bg-emerald-600 text-white hover:bg-emerald-500")
+        }
+      >
+        {active ? "Desmontar (unsubscribe)" : "Montar (subscribe)"}
+      </button>
+
+      <label className="flex flex-col gap-1 text-xs text-stone-600">
+        $params (texto)
+        <input
+          type="text"
+          value={text}
+          placeholder="onMount, computed, cursor…"
+          onChange={(event) => {
+            const value = event.target.value;
+            setText(value);
+            // Solo escribe en $params (y por lo tanto, si $search está
+            // montado, cancela el fetch en curso y dispara uno nuevo)
+            // 300ms después del último tecleo.
+            if (debounceRef.current) clearTimeout(debounceRef.current);
+            debounceRef.current = setTimeout(() => {
+              $params.set(value);
+            }, 300);
+          }}
+          className="rounded-md border border-stone-300 px-2 py-1 text-xs"
+        />
+      </label>
+
+      <div>
+        <p className="mb-1 text-[11px] font-medium text-stone-500">
+          Último estado ({data?.length ?? 0} resultados)
+        </p>
+        <div className="h-24 overflow-y-auto rounded-md border border-stone-100 bg-stone-50 text-[11px] text-stone-700">
+          {data?.length ? (
+            data.map((item) => (
+              <div
+                key={item.id}
+                className="border-b border-stone-100 px-2 py-1.5"
+              >
+                {item.title}
+              </div>
+            ))
+          ) : (
+            <p className="px-2 py-3 text-center text-stone-400">
+              {active ? "Sin resultados" : "Móntalo para buscar"}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div>
+        <p className="mb-1 text-[11px] font-medium text-stone-500">
+          Registro de actividad
+        </p>
+        <LogPanel log={log} logRef={logRef} />
+      </div>
+    </div>
+  );
+}
+
 export default function MyStateDemo() {
   // El único estado que vive en el padre: un contador para forzar un
   // remount completo de cada tarjeta (cada una crea sus propios stores,
@@ -926,10 +1120,14 @@ export default function MyStateDemo() {
 
       <div>
         <p className="mb-1 text-xs font-medium text-stone-500">
-          Parámetros reactivos: <code>computed</code> sin <code>onMount</code>,
-          no hay nada remoto que pedir perezosamente
+          Parámetros reactivos: dos variantes. Una deriva un valor sin fetch (
+          <code>computed</code>, sin <code>onMount</code>); la otra reacciona a
+          cada cambio de parámetro con un fetch cancelable
         </p>
-        <ImageParamsCard key={`image-${resetKey}`} />
+        <div className="grid gap-4 sm:grid-cols-2">
+          <ImageParamsCard key={`image-${resetKey}`} />
+          <SearchCard key={`search-${resetKey}`} />
+        </div>
       </div>
     </div>
   );

--- a/src/components/my-state-pattern/MyStateDemo.tsx
+++ b/src/components/my-state-pattern/MyStateDemo.tsx
@@ -168,6 +168,140 @@ function createSseDemoStore(log: (text: string) => void): {
   };
 }
 
+const FEED_PAGE_SIZE = 5;
+const FEED_TOTAL_PAGES = 4;
+
+type FeedItem = { id: number; title: string };
+type FeedPage = { items: FeedItem[]; nextCursor: number | null };
+type FeedState = {
+  items: FeedItem[];
+  cursor: number | null;
+  hasMore: boolean;
+  loading: boolean;
+  error: unknown;
+};
+
+const IDLE_FEED: FeedState = {
+  items: [],
+  cursor: null,
+  hasMore: true,
+  loading: true,
+  error: null,
+};
+
+// Simula una API paginada: `cursor` identifica la página a pedir (null =
+// primera), y cada respuesta trae su propio `nextCursor` — el estado que
+// hay que guardar para poder seguir pidiendo "la siguiente" sin volver a
+// pedir lo ya cargado.
+function simulateFeedPage(
+  cursor: number | null,
+  config: Config,
+  signal: AbortSignal,
+): Promise<FeedPage> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new DOMException("Aborted", "AbortError"));
+      return;
+    }
+    const timer = setTimeout(() => {
+      if (config.forceError) {
+        reject(new Error("No se pudo cargar la página"));
+        return;
+      }
+      const page = cursor ?? 0;
+      const start = page * FEED_PAGE_SIZE;
+      const items = Array.from({ length: FEED_PAGE_SIZE }, (_, i) => ({
+        id: start + i + 1,
+        title: `Artículo #${start + i + 1}`,
+      }));
+      const nextPage = page + 1;
+      resolve({
+        items,
+        nextCursor: nextPage < FEED_TOTAL_PAGES ? nextPage : null,
+      });
+    }, config.delayMs);
+    signal.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timer);
+        reject(new DOMException("Aborted", "AbortError"));
+      },
+      { once: true },
+    );
+  });
+}
+
+// A diferencia de Resource<T>, este store no reemplaza su valor en cada
+// respuesta: lo acumula (`items: [...prev.items, ...page.items]`). El
+// "state para continuar la paginación" es el cursor de la última página
+// resuelta, guardado junto a los items.
+function createFeedStore(log: (text: string) => void): {
+  $feed: WritableAtom<FeedState>;
+  config: Config;
+  loadMore: () => void;
+} {
+  const $feed = atom<FeedState>(IDLE_FEED);
+  const config: Config = { forceError: false, delayMs: 900 };
+  let controller: AbortController | null = null;
+
+  function loadPage(cursor: number | null, reason: string) {
+    controller?.abort();
+    const ownController = new AbortController();
+    controller = ownController;
+    const { signal } = ownController;
+
+    log(`[$feed] ${reason}`);
+    $feed.set({ ...$feed.get(), loading: true, error: null });
+
+    t(simulateFeedPage(cursor, config, signal)).then(([ok, error, page]) => {
+      if (signal.aborted) {
+        log("[$feed] fetch de página abortado, se descarta");
+        return;
+      }
+      if (!ok) {
+        $feed.set({ ...$feed.get(), loading: false, error });
+        log("[$feed] t() resolvió → ok:false");
+        return;
+      }
+      const prev = $feed.get();
+      $feed.set({
+        items: [...prev.items, ...page.items],
+        cursor: page.nextCursor,
+        hasMore: page.nextCursor !== null,
+        loading: false,
+        error: null,
+      });
+      log(`[$feed] t() resolvió → ok:true, +${page.items.length} items`);
+    });
+  }
+
+  onMount($feed, () => {
+    // Solo pide la primera página si todavía no hay nada: un remount
+    // rápido (desmontar y volver a montar antes del onStop) no debería
+    // tirar los items que ya se acumularon.
+    if ($feed.get().items.length === 0) {
+      loadPage(null, "onMount → sin items todavía, pide la primera página");
+    } else {
+      log("[$feed] onMount → ya había items, no repite la primera página");
+    }
+
+    return () => {
+      log("[$feed] onStop → aborta la página en curso, conserva los items");
+      controller?.abort();
+    };
+  });
+
+  return {
+    $feed,
+    config,
+    loadMore: () => {
+      const state = $feed.get();
+      if (!state.hasMore || state.loading) return;
+      loadPage(state.cursor, "cargar más → siguiente página con el cursor");
+    },
+  };
+}
+
 // Reading `store.get()` on a nanostores atom momentarily mounts it (even
 // without a lasting listener), which would trigger onMount's fetch as a
 // side effect of rendering. To keep "nobody is watching" truly inert
@@ -343,6 +477,110 @@ function SseCard({
   );
 }
 
+function FeedCard({
+  store,
+  config,
+  active,
+  onLoadMore,
+}: {
+  store: WritableAtom<FeedState>;
+  config: Config;
+  active: boolean;
+  onLoadMore: () => void;
+}) {
+  const state = useGatedValue<FeedState>(store, active, IDLE_FEED);
+  const [forceError, setForceError] = useState(config.forceError);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  // Infinite scroll real: observa el centinela al final de la lista y
+  // pide la siguiente página cuando entra en el viewport del contenedor.
+  useEffect(() => {
+    if (!active || !state.hasMore || state.loading) return;
+    const root = containerRef.current;
+    const sentinel = sentinelRef.current;
+    if (!root || !sentinel) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) onLoadMore();
+      },
+      { root, rootMargin: "40px" },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [active, state.hasMore, state.loading, onLoadMore]);
+
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border border-stone-200 bg-white p-4">
+      <div className="flex items-center justify-between">
+        <code className="text-sm font-semibold text-stone-800">$feed</code>
+        {state.error ? (
+          <StatusPill state={[false, state.error, null]} />
+        ) : state.loading ? (
+          <StatusPill state={[true, null, null]} />
+        ) : (
+          <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-100 px-2.5 py-0.5 text-xs font-medium text-emerald-800">
+            <span className="size-1.5 rounded-full bg-emerald-500" />
+            {state.items.length} items
+          </span>
+        )}
+      </div>
+
+      <div
+        ref={containerRef}
+        className="h-40 overflow-y-auto rounded-md border border-stone-100 bg-stone-50 text-[11px] text-stone-700"
+      >
+        {state.items.map((item) => (
+          <div key={item.id} className="border-b border-stone-100 px-2 py-1.5">
+            {item.title}
+          </div>
+        ))}
+        {state.hasMore ? (
+          <div
+            ref={sentinelRef}
+            className="px-2 py-3 text-center text-stone-400"
+          >
+            {state.loading ? "Cargando más…" : "— desplázate para cargar más —"}
+          </div>
+        ) : (
+          <div className="px-2 py-3 text-center text-stone-400">
+            — fin del feed —
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center justify-between gap-2 text-xs">
+        <label className="flex items-center gap-1.5 text-stone-600">
+          <input
+            type="checkbox"
+            checked={forceError}
+            onChange={() => {
+              config.forceError = !config.forceError;
+              setForceError(config.forceError);
+            }}
+            className="size-3.5"
+          />
+          forzar error de página
+        </label>
+        <button
+          onClick={onLoadMore}
+          disabled={!active || !state.hasMore || state.loading}
+          className="rounded-md border border-stone-300 bg-white px-2.5 py-1 font-medium text-stone-700 transition-colors hover:bg-stone-100 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          Cargar más
+        </button>
+      </div>
+
+      {state.error ? (
+        <p className="text-[11px] text-red-600">
+          {String((state.error as Error)?.message ?? state.error)}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
 export default function MyStateDemo() {
   const [active, setActive] = useState(false);
   const [log, setLog] = useState<Entry[]>([]);
@@ -362,7 +600,7 @@ export default function MyStateDemo() {
     ]);
   };
 
-  const { stores, retries, configs, $home, sse } = useMemo(() => {
+  const { stores, retries, configs, $home, sse, feed } = useMemo(() => {
     const configs: Record<string, Config> = {};
     const stores: Record<string, WritableAtom<Resource<unknown>>> = {};
     const retries: Record<string, () => void> = {};
@@ -385,7 +623,10 @@ export default function MyStateDemo() {
     // $liveMetrics no entra a $home: no es un recurso de una sola
     // resolución, pero comparte el mismo contrato onMount/onUnmount.
     const sse = createSseDemoStore(pushLog);
-    return { stores, retries, configs, $home, sse };
+    // $feed tampoco entra a $home: es un store incremental (paginado),
+    // no un Resource<T> de una sola resolución.
+    const feed = createFeedStore(pushLog);
+    return { stores, retries, configs, $home, sse, feed };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [generation]);
 
@@ -476,6 +717,22 @@ export default function MyStateDemo() {
             config={sse.config}
             active={active}
             onReconnect={sse.reconnect}
+          />
+        </div>
+      </div>
+
+      <div>
+        <p className="mb-1 text-xs font-medium text-stone-500">
+          Infinite scroll: store incremental, el cursor de la última página es
+          el estado que permite continuar la paginación
+        </p>
+        <div className="grid gap-4 sm:grid-cols-3">
+          <FeedCard
+            key={`feed-${generation}`}
+            store={feed.$feed}
+            config={feed.config}
+            active={active}
+            onLoadMore={feed.loadMore}
           />
         </div>
       </div>

--- a/src/components/my-state-pattern/MyStateDemo.tsx
+++ b/src/components/my-state-pattern/MyStateDemo.tsx
@@ -1,4 +1,10 @@
-import { atom, computed, onMount, type WritableAtom } from "nanostores";
+import {
+  atom,
+  computed,
+  onMount,
+  type ReadableAtom,
+  type WritableAtom,
+} from "nanostores";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 type Resource<T> = [loading: boolean, error: unknown, data: T | null];
@@ -302,6 +308,55 @@ function createFeedStore(log: (text: string) => void): {
   };
 }
 
+type ImageParams = {
+  text: string;
+  width: number;
+  height: number;
+  bg: string;
+  fg: string;
+};
+
+const DEFAULT_IMAGE_PARAMS: ImageParams = {
+  text: "my-state",
+  width: 320,
+  height: 160,
+  bg: "1c1917",
+  fg: "ffffff",
+};
+
+const IMAGE_SIZE_PRESETS: Array<Pick<ImageParams, "width" | "height">> = [
+  { width: 320, height: 160 },
+  { width: 240, height: 240 },
+  { width: 480, height: 200 },
+];
+
+// No hay recurso remoto que pedir: $params guarda lo que el usuario escribe,
+// y $imageUrl deriva sincrónicamente la URL a partir de esos parámetros con
+// un `computed` normal. No necesita onMount porque no hay nada async que
+// activar perezosamente — el navegador hace el fetch de la imagen solo,
+// declarativamente, al poner esa URL en un <img src>.
+function createImageParamsStore(): {
+  $params: WritableAtom<ImageParams>;
+  $imageUrl: ReadableAtom<string>;
+} {
+  const $params = atom<ImageParams>(DEFAULT_IMAGE_PARAMS);
+  const $imageUrl = computed($params, (params) => {
+    const text = encodeURIComponent(params.text.trim() || " ");
+    return `https://placehold.co/${params.width}x${params.height}/${params.bg}/${params.fg}?text=${text}`;
+  });
+  return { $params, $imageUrl };
+}
+
+// A diferencia de useGatedValue, este store no tiene onMount ni efectos
+// secundarios que activar: leer .get() en cualquier momento es inofensivo,
+// así que basta con un subscribe normal (lo mismo que hace useStore de
+// @nanostores/react).
+function useLiveValue<T>(store: ReadableAtom<T>): T {
+  const [value, setValue] = useState(() => store.get());
+  useEffect(() => store.listen(setValue), [store]);
+  return value;
+}
+
 // Reading `store.get()` on a nanostores atom momentarily mounts it (even
 // without a lasting listener), which would trigger onMount's fetch as a
 // side effect of rendering. To keep "nobody is watching" truly inert
@@ -581,6 +636,83 @@ function FeedCard({
   );
 }
 
+function ImageParamsCard({
+  paramsStore,
+  imageUrlStore,
+}: {
+  paramsStore: WritableAtom<ImageParams>;
+  imageUrlStore: ReadableAtom<string>;
+}) {
+  const params = useLiveValue(paramsStore);
+  const imageUrl = useLiveValue(imageUrlStore);
+  const [text, setText] = useState(params.text);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border border-stone-200 bg-white p-4 sm:flex-row">
+      <img
+        src={imageUrl}
+        alt={params.text || "placeholder"}
+        width={params.width}
+        height={params.height}
+        className="h-auto w-full max-w-[200px] rounded-md border border-stone-100 sm:w-1/2"
+      />
+
+      <div className="flex flex-1 flex-col gap-3">
+        <div className="flex items-center justify-between">
+          <code className="text-sm font-semibold text-stone-800">
+            $imageUrl
+          </code>
+          <span className="inline-flex items-center gap-1.5 rounded-full bg-stone-100 px-2.5 py-0.5 text-xs font-medium text-stone-600">
+            sin onMount, solo computed
+          </span>
+        </div>
+
+        <label className="flex flex-col gap-1 text-xs text-stone-600">
+          Texto
+          <input
+            type="text"
+            value={text}
+            onChange={(event) => {
+              const value = event.target.value;
+              setText(value);
+              // Debounce: solo escribe en $params (y por lo tanto pide una
+              // nueva imagen al servicio de placeholder) 300ms después del
+              // último tecleo, no en cada keystroke.
+              if (debounceRef.current) clearTimeout(debounceRef.current);
+              debounceRef.current = setTimeout(() => {
+                paramsStore.set({ ...paramsStore.get(), text: value });
+              }, 300);
+            }}
+            className="rounded-md border border-stone-300 px-2 py-1 text-xs"
+          />
+        </label>
+
+        <div className="flex flex-wrap gap-1.5">
+          {IMAGE_SIZE_PRESETS.map((size) => (
+            <button
+              key={`${size.width}x${size.height}`}
+              onClick={() => paramsStore.set({ ...paramsStore.get(), ...size })}
+              className={
+                "rounded-md border px-2 py-1 text-[11px] font-medium transition-colors " +
+                (params.width === size.width && params.height === size.height
+                  ? "border-stone-900 bg-stone-900 text-white"
+                  : "border-stone-300 bg-white text-stone-700 hover:bg-stone-100")
+              }
+            >
+              {size.width}×{size.height}
+            </button>
+          ))}
+        </div>
+
+        <pre className="overflow-x-auto rounded-md bg-stone-50 p-2 text-[11px] leading-relaxed text-stone-700">
+          {imageUrl}
+        </pre>
+      </div>
+    </div>
+  );
+}
+
 export default function MyStateDemo() {
   const [active, setActive] = useState(false);
   const [log, setLog] = useState<Entry[]>([]);
@@ -600,7 +732,7 @@ export default function MyStateDemo() {
     ]);
   };
 
-  const { stores, retries, configs, $home, sse, feed } = useMemo(() => {
+  const { stores, retries, configs, $home, sse, feed, image } = useMemo(() => {
     const configs: Record<string, Config> = {};
     const stores: Record<string, WritableAtom<Resource<unknown>>> = {};
     const retries: Record<string, () => void> = {};
@@ -626,7 +758,10 @@ export default function MyStateDemo() {
     // $feed tampoco entra a $home: es un store incremental (paginado),
     // no un Resource<T> de una sola resolución.
     const feed = createFeedStore(pushLog);
-    return { stores, retries, configs, $home, sse, feed };
+    // $params/$imageUrl tampoco entra a $home: no representa un recurso
+    // remoto en absoluto, es estado local derivado sincrónicamente.
+    const image = createImageParamsStore();
+    return { stores, retries, configs, $home, sse, feed, image };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [generation]);
 
@@ -735,6 +870,18 @@ export default function MyStateDemo() {
             onLoadMore={feed.loadMore}
           />
         </div>
+      </div>
+
+      <div>
+        <p className="mb-1 text-xs font-medium text-stone-500">
+          Parámetros reactivos: <code>computed</code> sin <code>onMount</code>,
+          no hay nada remoto que pedir perezosamente
+        </p>
+        <ImageParamsCard
+          key={`image-${generation}`}
+          paramsStore={image.$params}
+          imageUrlStore={image.$imageUrl}
+        />
       </div>
 
       <div>

--- a/src/components/my-state-pattern/MyStateDemo.tsx
+++ b/src/components/my-state-pattern/MyStateDemo.tsx
@@ -1,0 +1,327 @@
+import { atom, computed, onMount, type WritableAtom } from "nanostores";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+type Resource<T> = [loading: boolean, error: unknown, data: T | null];
+
+type Ok<T> = [ok: true, error: null, data: T];
+type Err = [ok: false, error: unknown, data: null];
+
+const t = async <T,>(promise: Promise<T>): Promise<Ok<T> | Err> => {
+  try {
+    const data = await promise;
+    return [true, null, data];
+  } catch (error) {
+    return [false, error, null];
+  }
+};
+
+type Entry = { id: number; time: string; text: string };
+
+type Config = { forceError: boolean; delayMs: number };
+
+type ResourceDef = {
+  key: "session" | "recentArticles" | "serverHealth";
+  sample: unknown;
+};
+
+const RESOURCE_DEFS: ResourceDef[] = [
+  { key: "session", sample: { user: "jondotsoy", plan: "pro" } },
+  {
+    key: "recentArticles",
+    sample: [{ id: "my-state-pattern" }, { id: "otro-articulo" }],
+  },
+  { key: "serverHealth", sample: { status: "ok", latencyMs: 42 } },
+];
+
+function simulate(def: ResourceDef, config: Config): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      if (config.forceError) reject(new Error(`No se pudo obtener ${def.key}`));
+      else resolve(def.sample);
+    }, config.delayMs);
+  });
+}
+
+function createDemoStore(
+  def: ResourceDef,
+  config: Config,
+  log: (text: string) => void,
+): WritableAtom<Resource<unknown>> {
+  const $resource = atom<Resource<unknown>>([true, null, null]);
+
+  onMount($resource, () => {
+    let cancelled = false;
+    log(`[$${def.key}] onMount → nadie escuchaba, ahora sí: fetch()`);
+    $resource.set([true, null, null]);
+
+    t(simulate(def, config)).then(([ok, error, data]) => {
+      if (cancelled) return;
+      $resource.set([false, error, data as unknown]);
+      log(`[$${def.key}] t() resolvió → ok:${ok}`);
+    });
+
+    return () => {
+      cancelled = true;
+      log(`[$${def.key}] onStop → último subscriptor se fue, limpiando`);
+    };
+  });
+
+  return $resource;
+}
+
+// Reading `store.get()` on a nanostores atom momentarily mounts it (even
+// without a lasting listener), which would trigger onMount's fetch as a
+// side effect of rendering. To keep "nobody is watching" truly inert
+// (including during SSR), never touch the store until `active` is true.
+function useGatedValue<T>(store: WritableAtom<T>, active: boolean, idle: T): T {
+  const [value, setValue] = useState<T>(idle);
+
+  useEffect(() => {
+    if (!active) {
+      setValue(idle);
+      return;
+    }
+    setValue(store.get());
+    return store.listen(setValue);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [store, active]);
+
+  return value;
+}
+
+function StatusPill({ state }: { state: Resource<unknown> }) {
+  const [loading, error] = state;
+  if (loading)
+    return (
+      <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-800">
+        <span className="size-1.5 animate-pulse rounded-full bg-amber-500" />
+        loading
+      </span>
+    );
+  if (error)
+    return (
+      <span className="inline-flex items-center gap-1.5 rounded-full bg-red-100 px-2.5 py-0.5 text-xs font-medium text-red-800">
+        <span className="size-1.5 rounded-full bg-red-500" />
+        error
+      </span>
+    );
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-100 px-2.5 py-0.5 text-xs font-medium text-emerald-800">
+      <span className="size-1.5 rounded-full bg-emerald-500" />
+      ok
+    </span>
+  );
+}
+
+function ResourceCard({
+  def,
+  store,
+  config,
+  active,
+  log,
+}: {
+  def: ResourceDef;
+  store: WritableAtom<Resource<unknown>>;
+  config: Config;
+  active: boolean;
+  log: (text: string) => void;
+}) {
+  const state = useGatedValue<Resource<unknown>>(store, active, [
+    true,
+    null,
+    null,
+  ]);
+  const [, error, data] = state;
+  const [forceError, setForceError] = useState(config.forceError);
+
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border border-stone-200 bg-white p-4">
+      <div className="flex items-center justify-between">
+        <code className="text-sm font-semibold text-stone-800">${def.key}</code>
+        <StatusPill state={state} />
+      </div>
+
+      <pre className="overflow-x-auto rounded-md bg-stone-50 p-2 text-[11px] leading-relaxed text-stone-700">
+        {`[${state[0]}, ${
+          error
+            ? JSON.stringify(String((error as Error)?.message ?? error))
+            : "null"
+        }, ${data ? JSON.stringify(data) : "null"}]`}
+      </pre>
+
+      <div className="flex items-center justify-between gap-2 text-xs">
+        <label className="flex items-center gap-1.5 text-stone-600">
+          <input
+            type="checkbox"
+            checked={forceError}
+            onChange={() => {
+              config.forceError = !config.forceError;
+              setForceError(config.forceError);
+            }}
+            className="size-3.5"
+          />
+          forzar error
+        </label>
+        <button
+          onClick={() => {
+            store.set([true, null, null]);
+            log(`[$${def.key}] reintento manual`);
+            t(simulate(def, config)).then(([ok, error, data]) => {
+              store.set([false, error, data as unknown]);
+              log(`[$${def.key}] t() resolvió → ok:${ok}`);
+            });
+          }}
+          disabled={!active}
+          className="rounded-md border border-stone-300 bg-white px-2.5 py-1 font-medium text-stone-700 transition-colors hover:bg-stone-100 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          Reintentar
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default function MyStateDemo() {
+  const [active, setActive] = useState(false);
+  const [log, setLog] = useState<Entry[]>([]);
+  const [generation, setGeneration] = useState(0);
+  const logRef = useRef<HTMLDivElement>(null);
+  const logIdRef = useRef(0);
+
+  const pushLog = (text: string) => {
+    logIdRef.current += 1;
+    setLog((prev) => [
+      ...prev.slice(-49),
+      {
+        id: logIdRef.current,
+        time: new Date().toLocaleTimeString("es-CL", { hour12: false }),
+        text,
+      },
+    ]);
+  };
+
+  const { stores, configs, $home } = useMemo(() => {
+    const configs: Record<string, Config> = {};
+    const stores: Record<string, WritableAtom<Resource<unknown>>> = {};
+    for (const def of RESOURCE_DEFS) {
+      const config: Config = { forceError: false, delayMs: 900 };
+      configs[def.key] = config;
+      stores[def.key] = createDemoStore(def, config, pushLog);
+    }
+    const $home = computed(
+      RESOURCE_DEFS.map((d) => stores[d.key]),
+      (...states) =>
+        Object.fromEntries(RESOURCE_DEFS.map((d, i) => [d.key, states[i]])),
+    );
+    return { stores, configs, $home };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [generation]);
+
+  useEffect(() => {
+    logRef.current?.scrollTo({ top: logRef.current.scrollHeight });
+  }, [log]);
+
+  const idleHome = useMemo(
+    () =>
+      Object.fromEntries(RESOURCE_DEFS.map((d) => [d.key, [true, null, null]])),
+    [],
+  );
+  const homeState = useGatedValue($home, active, idleHome);
+
+  const handleToggleSubscribe = () => {
+    setActive((prev) => {
+      const next = !prev;
+      pushLog(
+        next
+          ? "$home.subscribe() → primer subscriptor, se activa onMount de cada recurso"
+          : "$home unsubscribe → sin subscriptores, se limpia cada recurso",
+      );
+      return next;
+    });
+  };
+
+  const handleRemount = () => {
+    setActive(false);
+    setLog([]);
+    setGeneration((g) => g + 1);
+    pushLog("Stores recreados desde cero (simula recargar la página)");
+  };
+
+  return (
+    <div className="flex flex-col gap-6 rounded-xl border border-stone-200 bg-stone-50/50 p-4 sm:p-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold text-stone-800">
+            $home = computed([$session, $recentArticles, $serverHealth])
+          </p>
+          <p className="text-xs text-stone-500">
+            Nada se pide hasta que alguien se suscribe a <code>$home</code>.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={handleRemount}
+            className="rounded-md border border-stone-300 bg-white px-3 py-1.5 text-xs font-medium text-stone-700 transition-colors hover:bg-stone-100"
+          >
+            Recargar página
+          </button>
+          <button
+            onClick={handleToggleSubscribe}
+            className={
+              "rounded-md px-3 py-1.5 text-xs font-semibold transition-colors " +
+              (active
+                ? "bg-stone-900 text-white hover:bg-stone-700"
+                : "bg-emerald-600 text-white hover:bg-emerald-500")
+            }
+          >
+            {active ? "Desmontar (unsubscribe)" : "Montar HomePage (subscribe)"}
+          </button>
+        </div>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-3">
+        {RESOURCE_DEFS.map((def) => (
+          <ResourceCard
+            key={`${def.key}-${generation}`}
+            def={def}
+            store={stores[def.key]}
+            config={configs[def.key]}
+            active={active}
+            log={pushLog}
+          />
+        ))}
+      </div>
+
+      <div>
+        <p className="mb-1 text-xs font-medium text-stone-500">
+          Estado combinado de la página ($home.get())
+        </p>
+        <pre className="max-h-32 overflow-auto rounded-md bg-stone-900 p-3 text-[11px] leading-relaxed text-stone-100">
+          {JSON.stringify(homeState, null, 2)}
+        </pre>
+      </div>
+
+      <div>
+        <p className="mb-1 text-xs font-medium text-stone-500">
+          Registro de actividad (onMount / onStop / t())
+        </p>
+        <div
+          ref={logRef}
+          className="h-32 overflow-y-auto rounded-md border border-stone-200 bg-white p-2 font-mono text-[11px] leading-relaxed text-stone-600"
+        >
+          {log.length === 0 && (
+            <p className="text-stone-400">
+              Sin actividad todavía. Monta la página para ver los fetch
+              dispararse.
+            </p>
+          )}
+          {log.map((entry) => (
+            <p key={entry.id}>
+              <span className="text-stone-400">{entry.time}</span> {entry.text}
+            </p>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/my-state-pattern/MyStateDemo.tsx
+++ b/src/components/my-state-pattern/MyStateDemo.tsx
@@ -178,10 +178,9 @@ const FEED_PAGE_SIZE = 5;
 const FEED_TOTAL_PAGES = 4;
 
 type FeedItem = { id: number; title: string };
-type FeedPage = { items: FeedItem[]; nextCursor: number | null };
+type FeedPage = { items: FeedItem[]; hasMore: boolean };
 type FeedState = {
   items: FeedItem[];
-  cursor: number | null;
   hasMore: boolean;
   loading: boolean;
   error: unknown;
@@ -189,18 +188,15 @@ type FeedState = {
 
 const IDLE_FEED: FeedState = {
   items: [],
-  cursor: null,
   hasMore: true,
   loading: true,
   error: null,
 };
 
-// Simula una API paginada: `cursor` identifica la página a pedir (null =
-// primera), y cada respuesta trae su propio `nextCursor` — el estado que
-// hay que guardar para poder seguir pidiendo "la siguiente" sin volver a
-// pedir lo ya cargado.
+// Simula una API paginada: `cursor` es directamente el número de página
+// (0, 1, 2…), y la respuesta dice si queda algo más para pedir.
 function simulateFeedPage(
-  cursor: number | null,
+  cursor: number,
   config: Config,
   signal: AbortSignal,
 ): Promise<FeedPage> {
@@ -214,17 +210,12 @@ function simulateFeedPage(
         reject(new Error("No se pudo cargar la página"));
         return;
       }
-      const page = cursor ?? 0;
-      const start = page * FEED_PAGE_SIZE;
+      const start = cursor * FEED_PAGE_SIZE;
       const items = Array.from({ length: FEED_PAGE_SIZE }, (_, i) => ({
         id: start + i + 1,
         title: `Artículo #${start + i + 1}`,
       }));
-      const nextPage = page + 1;
-      resolve({
-        items,
-        nextCursor: nextPage < FEED_TOTAL_PAGES ? nextPage : null,
-      });
+      resolve({ items, hasMore: cursor + 1 < FEED_TOTAL_PAGES });
     }, config.delayMs);
     signal.addEventListener(
       "abort",
@@ -237,73 +228,77 @@ function simulateFeedPage(
   });
 }
 
-// A diferencia de Resource<T>, este store no reemplaza su valor en cada
-// respuesta: lo acumula (`items: [...prev.items, ...page.items]`). El
-// "state para continuar la paginación" es el cursor de la última página
-// resuelta, guardado junto a los items.
+// Mismo patrón que $params/$search: dos stores separados. $cursor no sabe
+// nada de fetch — solo guarda qué página toca pedir. $feed es el único
+// con onMount, y al montarse se subscribe a $cursor con subscribe() (así
+// la página 0 sale de inmediato). A diferencia de $search, la respuesta
+// no reemplaza el valor: se concatena a los items que ya había.
 function createFeedStore(log: (text: string) => void): {
+  $cursor: WritableAtom<number>;
   $feed: WritableAtom<FeedState>;
   config: Config;
   loadMore: () => void;
 } {
+  const $cursor = atom<number>(0);
   const $feed = atom<FeedState>(IDLE_FEED);
   const config: Config = { forceError: false, delayMs: 900 };
   let controller: AbortController | null = null;
-
-  function loadPage(cursor: number | null, reason: string) {
-    controller?.abort();
-    const ownController = new AbortController();
-    controller = ownController;
-    const { signal } = ownController;
-
-    log(`[$feed] ${reason}`);
-    $feed.set({ ...$feed.get(), loading: true, error: null });
-
-    t(simulateFeedPage(cursor, config, signal)).then(([ok, error, page]) => {
-      if (signal.aborted) {
-        log("[$feed] fetch de página abortado, se descarta");
-        return;
-      }
-      if (!ok) {
-        $feed.set({ ...$feed.get(), loading: false, error });
-        log("[$feed] t() resolvió → ok:false");
-        return;
-      }
-      const prev = $feed.get();
-      $feed.set({
-        items: [...prev.items, ...page.items],
-        cursor: page.nextCursor,
-        hasMore: page.nextCursor !== null,
-        loading: false,
-        error: null,
-      });
-      log(`[$feed] t() resolvió → ok:true, +${page.items.length} items`);
-    });
-  }
+  // Un remount rápido no debería repetir la última página ya cargada:
+  // subscribe() dispara de nuevo con el cursor actual al re-montar, así
+  // que hay que distinguir "cursor nuevo" de "el mismo de la vez pasada".
+  let lastFetchedCursor: number | null = null;
 
   onMount($feed, () => {
-    // Solo pide la primera página si todavía no hay nada: un remount
-    // rápido (desmontar y volver a montar antes del onStop) no debería
-    // tirar los items que ya se acumularon.
-    if ($feed.get().items.length === 0) {
-      loadPage(null, "onMount → sin items todavía, pide la primera página");
-    } else {
-      log("[$feed] onMount → ya había items, no repite la primera página");
-    }
+    log("onMount → subscribe a $cursor");
+
+    const unsubscribe = $cursor.subscribe((cursor) => {
+      if (cursor === lastFetchedCursor) {
+        log("cursor sin cambios desde el último fetch, no repite la página");
+        return;
+      }
+      lastFetchedCursor = cursor;
+
+      controller?.abort();
+      const ownController = new AbortController();
+      controller = ownController;
+      const { signal } = ownController;
+      $feed.set({ ...$feed.get(), loading: true, error: null });
+
+      t(simulateFeedPage(cursor, config, signal)).then(([ok, error, page]) => {
+        if (signal.aborted) {
+          log("fetch de página abortado, se descarta");
+          return;
+        }
+        const prev = $feed.get();
+        $feed.set(
+          ok
+            ? {
+                items: [...prev.items, ...page.items],
+                hasMore: page.hasMore,
+                loading: false,
+                error: null,
+              }
+            : { ...prev, loading: false, error },
+        );
+        log(`t() resolvió → ok:${ok}`);
+      });
+    });
 
     return () => {
-      log("[$feed] onStop → aborta la página en curso, conserva los items");
+      log("onStop → unsubscribe de $cursor, aborta la página en curso");
+      unsubscribe();
       controller?.abort();
     };
   });
 
   return {
+    $cursor,
     $feed,
     config,
     loadMore: () => {
       const state = $feed.get();
       if (!state.hasMore || state.loading) return;
-      loadPage(state.cursor, "cargar más → siguiente página con el cursor");
+      $cursor.set($cursor.get() + 1);
     },
   };
 }
@@ -759,13 +754,21 @@ function FeedCard() {
   const [active, setActive] = useState(false);
   const { log, push, logRef } = useCardLog();
 
-  const { store, config, loadMore } = useMemo(() => {
+  const { store, cursorStore, config, loadMore } = useMemo(() => {
     const demo = createFeedStore(push);
-    return { store: demo.$feed, config: demo.config, loadMore: demo.loadMore };
+    return {
+      store: demo.$feed,
+      cursorStore: demo.$cursor,
+      config: demo.config,
+      loadMore: demo.loadMore,
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const state = useGatedValue<FeedState>(store, active, IDLE_FEED);
+  // $cursor no tiene onMount: leer su valor en cualquier momento es
+  // inofensivo, así que no necesita el mismo gateo que $feed.
+  const cursor = useLiveValue(cursorStore);
   const [forceError, setForceError] = useState(config.forceError);
   const containerRef = useRef<HTMLDivElement>(null);
   const sentinelRef = useRef<HTMLDivElement>(null);
@@ -829,7 +832,8 @@ function FeedCard() {
       </button>
 
       <p className="mb-[-8px] text-[11px] font-medium text-stone-500">
-        Último estado ({state.items.length} items acumulados)
+        Último estado ({state.items.length} items, <code>$cursor</code> ={" "}
+        {cursor})
       </p>
       <div
         ref={containerRef}

--- a/src/components/my-state-pattern/MyStateDemo.tsx
+++ b/src/components/my-state-pattern/MyStateDemo.tsx
@@ -5,7 +5,7 @@ import {
   type ReadableAtom,
   type WritableAtom,
 } from "nanostores";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { type RefObject, useEffect, useMemo, useRef, useState } from "react";
 
 type Resource<T> = [loading: boolean, error: unknown, data: T | null];
 
@@ -377,6 +377,58 @@ function useGatedValue<T>(store: WritableAtom<T>, active: boolean, idle: T): T {
   return value;
 }
 
+// Cada tarjeta lleva su propio registro de actividad: nada se comparte
+// entre ejemplos, así montar/desmontar uno no ensucia el log de otro.
+function useCardLog() {
+  const [log, setLog] = useState<Entry[]>([]);
+  const idRef = useRef(0);
+  const logRef = useRef<HTMLDivElement>(null);
+
+  const push = (text: string) => {
+    idRef.current += 1;
+    setLog((prev) => [
+      ...prev.slice(-19),
+      {
+        id: idRef.current,
+        time: new Date().toLocaleTimeString("es-CL", { hour12: false }),
+        text,
+      },
+    ]);
+  };
+
+  useEffect(() => {
+    logRef.current?.scrollTo({ top: logRef.current.scrollHeight });
+  }, [log]);
+
+  return { log, push, logRef };
+}
+
+function LogPanel({
+  log,
+  logRef,
+}: {
+  log: Entry[];
+  logRef: RefObject<HTMLDivElement | null>;
+}) {
+  return (
+    <div
+      ref={logRef}
+      className="h-24 overflow-y-auto rounded-md border border-stone-200 bg-white p-2 font-mono text-[10px] leading-relaxed text-stone-600"
+    >
+      {log.length === 0 && (
+        <p className="text-stone-400">
+          Sin actividad. Móntalo para ver su ciclo de vida.
+        </p>
+      )}
+      {log.map((entry) => (
+        <p key={entry.id}>
+          <span className="text-stone-400">{entry.time}</span> {entry.text}
+        </p>
+      ))}
+    </div>
+  );
+}
+
 function StatusPill({ state }: { state: Resource<unknown> }) {
   const [loading, error] = state;
   if (loading)
@@ -401,19 +453,22 @@ function StatusPill({ state }: { state: Resource<unknown> }) {
   );
 }
 
-function ResourceCard({
-  def,
-  store,
-  config,
-  active,
-  onRetry,
-}: {
-  def: ResourceDef;
-  store: WritableAtom<Resource<unknown>>;
-  config: Config;
-  active: boolean;
-  onRetry: () => void;
-}) {
+function ResourceCard({ def }: { def: ResourceDef }) {
+  const [active, setActive] = useState(false);
+  const { log, push, logRef } = useCardLog();
+
+  // Este ejemplo es independiente: su propio store, su propio config y su
+  // propio ciclo de vida, sin depender de ningún otro ejemplo de la página.
+  const { store, config, retry } = useMemo(() => {
+    // nanostores espera ~1s (STORE_UNMOUNT_DELAY) tras el último unsubscribe
+    // antes de llamar el onUnmount; el delay simulado debe ser mayor a eso
+    // para que desmontar durante la carga demuestre un abort real.
+    const config: Config = { forceError: false, delayMs: 2200 };
+    const demoStore = createDemoStore(def, config, push);
+    return { store: demoStore.$resource, config, retry: demoStore.retry };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const state = useGatedValue<Resource<unknown>>(store, active, [
     true,
     null,
@@ -422,6 +477,18 @@ function ResourceCard({
   const [, error, data] = state;
   const [forceError, setForceError] = useState(config.forceError);
 
+  const handleToggle = () => {
+    setActive((prev) => {
+      const next = !prev;
+      push(
+        next
+          ? "subscribe() → primer subscriptor, se activa onMount"
+          : "unsubscribe → sin subscriptores, se agenda onStop",
+      );
+      return next;
+    });
+  };
+
   return (
     <div className="flex flex-col gap-3 rounded-lg border border-stone-200 bg-white p-4">
       <div className="flex items-center justify-between">
@@ -429,13 +496,30 @@ function ResourceCard({
         <StatusPill state={state} />
       </div>
 
-      <pre className="overflow-x-auto rounded-md bg-stone-50 p-2 text-[11px] leading-relaxed text-stone-700">
-        {`[${state[0]}, ${
-          error
-            ? JSON.stringify(String((error as Error)?.message ?? error))
-            : "null"
-        }, ${data ? JSON.stringify(data) : "null"}]`}
-      </pre>
+      <button
+        onClick={handleToggle}
+        className={
+          "rounded-md px-2.5 py-1 text-xs font-semibold transition-colors " +
+          (active
+            ? "bg-stone-900 text-white hover:bg-stone-700"
+            : "bg-emerald-600 text-white hover:bg-emerald-500")
+        }
+      >
+        {active ? "Desmontar (unsubscribe)" : "Montar (subscribe)"}
+      </button>
+
+      <div>
+        <p className="mb-1 text-[11px] font-medium text-stone-500">
+          Último estado
+        </p>
+        <pre className="overflow-x-auto rounded-md bg-stone-50 p-2 text-[11px] leading-relaxed text-stone-700">
+          {`[${state[0]}, ${
+            error
+              ? JSON.stringify(String((error as Error)?.message ?? error))
+              : "null"
+          }, ${data ? JSON.stringify(data) : "null"}]`}
+        </pre>
+      </div>
 
       <div className="flex items-center justify-between gap-2 text-xs">
         <label className="flex items-center gap-1.5 text-stone-600">
@@ -451,28 +535,38 @@ function ResourceCard({
           forzar error
         </label>
         <button
-          onClick={onRetry}
+          onClick={retry}
           disabled={!active}
           className="rounded-md border border-stone-300 bg-white px-2.5 py-1 font-medium text-stone-700 transition-colors hover:bg-stone-100 disabled:cursor-not-allowed disabled:opacity-40"
         >
           Reintentar
         </button>
       </div>
+
+      <div>
+        <p className="mb-1 text-[11px] font-medium text-stone-500">
+          Registro de actividad
+        </p>
+        <LogPanel log={log} logRef={logRef} />
+      </div>
     </div>
   );
 }
 
-function SseCard({
-  store,
-  config,
-  active,
-  onReconnect,
-}: {
-  store: WritableAtom<Resource<SseTick>>;
-  config: Config;
-  active: boolean;
-  onReconnect: () => void;
-}) {
+function SseCard() {
+  const [active, setActive] = useState(false);
+  const { log, push, logRef } = useCardLog();
+
+  const { store, config, reconnect } = useMemo(() => {
+    const demo = createSseDemoStore(push);
+    return {
+      store: demo.$resource,
+      config: demo.config,
+      reconnect: demo.reconnect,
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const state = useGatedValue<Resource<SseTick>>(store, active, [
     true,
     null,
@@ -480,6 +574,18 @@ function SseCard({
   ]);
   const [loading, error, data] = state;
   const [forceError, setForceError] = useState(config.forceError);
+
+  const handleToggle = () => {
+    setActive((prev) => {
+      const next = !prev;
+      push(
+        next
+          ? "subscribe() → primer subscriptor, se activa onMount"
+          : "unsubscribe → sin subscriptores, se agenda onStop",
+      );
+      return next;
+    });
+  };
 
   return (
     <div className="flex flex-col gap-3 rounded-lg border border-stone-200 bg-white p-4">
@@ -499,13 +605,30 @@ function SseCard({
         )}
       </div>
 
-      <pre className="overflow-x-auto rounded-md bg-stone-50 p-2 text-[11px] leading-relaxed text-stone-700">
-        {`[${state[0]}, ${
-          error
-            ? JSON.stringify(String((error as Error)?.message ?? error))
-            : "null"
-        }, ${data ? JSON.stringify(data) : "null"}]`}
-      </pre>
+      <button
+        onClick={handleToggle}
+        className={
+          "rounded-md px-2.5 py-1 text-xs font-semibold transition-colors " +
+          (active
+            ? "bg-stone-900 text-white hover:bg-stone-700"
+            : "bg-emerald-600 text-white hover:bg-emerald-500")
+        }
+      >
+        {active ? "Desmontar (unsubscribe)" : "Montar (subscribe)"}
+      </button>
+
+      <div>
+        <p className="mb-1 text-[11px] font-medium text-stone-500">
+          Último estado
+        </p>
+        <pre className="overflow-x-auto rounded-md bg-stone-50 p-2 text-[11px] leading-relaxed text-stone-700">
+          {`[${state[0]}, ${
+            error
+              ? JSON.stringify(String((error as Error)?.message ?? error))
+              : "null"
+          }, ${data ? JSON.stringify(data) : "null"}]`}
+        </pre>
+      </div>
 
       <div className="flex items-center justify-between gap-2 text-xs">
         <label className="flex items-center gap-1.5 text-stone-600">
@@ -521,32 +644,50 @@ function SseCard({
           simular corte
         </label>
         <button
-          onClick={onReconnect}
+          onClick={reconnect}
           disabled={!active}
           className="rounded-md border border-stone-300 bg-white px-2.5 py-1 font-medium text-stone-700 transition-colors hover:bg-stone-100 disabled:cursor-not-allowed disabled:opacity-40"
         >
           Reconectar
         </button>
       </div>
+
+      <div>
+        <p className="mb-1 text-[11px] font-medium text-stone-500">
+          Registro de actividad
+        </p>
+        <LogPanel log={log} logRef={logRef} />
+      </div>
     </div>
   );
 }
 
-function FeedCard({
-  store,
-  config,
-  active,
-  onLoadMore,
-}: {
-  store: WritableAtom<FeedState>;
-  config: Config;
-  active: boolean;
-  onLoadMore: () => void;
-}) {
+function FeedCard() {
+  const [active, setActive] = useState(false);
+  const { log, push, logRef } = useCardLog();
+
+  const { store, config, loadMore } = useMemo(() => {
+    const demo = createFeedStore(push);
+    return { store: demo.$feed, config: demo.config, loadMore: demo.loadMore };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const state = useGatedValue<FeedState>(store, active, IDLE_FEED);
   const [forceError, setForceError] = useState(config.forceError);
   const containerRef = useRef<HTMLDivElement>(null);
   const sentinelRef = useRef<HTMLDivElement>(null);
+
+  const handleToggle = () => {
+    setActive((prev) => {
+      const next = !prev;
+      push(
+        next
+          ? "subscribe() → primer subscriptor, se activa onMount"
+          : "unsubscribe → sin subscriptores, se agenda onStop",
+      );
+      return next;
+    });
+  };
 
   // Infinite scroll real: observa el centinela al final de la lista y
   // pide la siguiente página cuando entra en el viewport del contenedor.
@@ -558,13 +699,13 @@ function FeedCard({
 
     const observer = new IntersectionObserver(
       (entries) => {
-        if (entries[0]?.isIntersecting) onLoadMore();
+        if (entries[0]?.isIntersecting) loadMore();
       },
       { root, rootMargin: "40px" },
     );
     observer.observe(sentinel);
     return () => observer.disconnect();
-  }, [active, state.hasMore, state.loading, onLoadMore]);
+  }, [active, state.hasMore, state.loading, loadMore]);
 
   return (
     <div className="flex flex-col gap-3 rounded-lg border border-stone-200 bg-white p-4">
@@ -582,6 +723,21 @@ function FeedCard({
         )}
       </div>
 
+      <button
+        onClick={handleToggle}
+        className={
+          "rounded-md px-2.5 py-1 text-xs font-semibold transition-colors " +
+          (active
+            ? "bg-stone-900 text-white hover:bg-stone-700"
+            : "bg-emerald-600 text-white hover:bg-emerald-500")
+        }
+      >
+        {active ? "Desmontar (unsubscribe)" : "Montar (subscribe)"}
+      </button>
+
+      <p className="mb-[-8px] text-[11px] font-medium text-stone-500">
+        Último estado ({state.items.length} items acumulados)
+      </p>
       <div
         ref={containerRef}
         className="h-40 overflow-y-auto rounded-md border border-stone-100 bg-stone-50 text-[11px] text-stone-700"
@@ -619,7 +775,7 @@ function FeedCard({
           forzar error de página
         </label>
         <button
-          onClick={onLoadMore}
+          onClick={loadMore}
           disabled={!active || !state.hasMore || state.loading}
           className="rounded-md border border-stone-300 bg-white px-2.5 py-1 font-medium text-stone-700 transition-colors hover:bg-stone-100 disabled:cursor-not-allowed disabled:opacity-40"
         >
@@ -632,17 +788,24 @@ function FeedCard({
           {String((state.error as Error)?.message ?? state.error)}
         </p>
       ) : null}
+
+      <div>
+        <p className="mb-1 text-[11px] font-medium text-stone-500">
+          Registro de actividad
+        </p>
+        <LogPanel log={log} logRef={logRef} />
+      </div>
     </div>
   );
 }
 
-function ImageParamsCard({
-  paramsStore,
-  imageUrlStore,
-}: {
-  paramsStore: WritableAtom<ImageParams>;
-  imageUrlStore: ReadableAtom<string>;
-}) {
+function ImageParamsCard() {
+  // También es independiente: no depende de que ningún otro ejemplo se
+  // haya montado, y tampoco tiene ciclo de vida propio que gatear.
+  const { $params: paramsStore, $imageUrl: imageUrlStore } = useMemo(
+    () => createImageParamsStore(),
+    [],
+  );
   const params = useLiveValue(paramsStore);
   const imageUrl = useLiveValue(imageUrlStore);
   const [text, setText] = useState(params.text);
@@ -714,129 +877,30 @@ function ImageParamsCard({
 }
 
 export default function MyStateDemo() {
-  const [active, setActive] = useState(false);
-  const [log, setLog] = useState<Entry[]>([]);
-  const [generation, setGeneration] = useState(0);
-  const logRef = useRef<HTMLDivElement>(null);
-  const logIdRef = useRef(0);
-
-  const pushLog = (text: string) => {
-    logIdRef.current += 1;
-    setLog((prev) => [
-      ...prev.slice(-49),
-      {
-        id: logIdRef.current,
-        time: new Date().toLocaleTimeString("es-CL", { hour12: false }),
-        text,
-      },
-    ]);
-  };
-
-  const { stores, retries, configs, $home, sse, feed, image } = useMemo(() => {
-    const configs: Record<string, Config> = {};
-    const stores: Record<string, WritableAtom<Resource<unknown>>> = {};
-    const retries: Record<string, () => void> = {};
-    for (const def of RESOURCE_DEFS) {
-      // nanostores espera ~1s (STORE_UNMOUNT_DELAY) tras el último
-      // unsubscribe antes de llamar el onUnmount; el delay simulado debe
-      // ser mayor a eso para que desmontar durante la carga demuestre un
-      // abort real y no una simple carrera ganada por el fetch.
-      const config: Config = { forceError: false, delayMs: 2200 };
-      configs[def.key] = config;
-      const demoStore = createDemoStore(def, config, pushLog);
-      stores[def.key] = demoStore.$resource;
-      retries[def.key] = demoStore.retry;
-    }
-    const $home = computed(
-      RESOURCE_DEFS.map((d) => stores[d.key]),
-      (...states) =>
-        Object.fromEntries(RESOURCE_DEFS.map((d, i) => [d.key, states[i]])),
-    );
-    // $liveMetrics no entra a $home: no es un recurso de una sola
-    // resolución, pero comparte el mismo contrato onMount/onUnmount.
-    const sse = createSseDemoStore(pushLog);
-    // $feed tampoco entra a $home: es un store incremental (paginado),
-    // no un Resource<T> de una sola resolución.
-    const feed = createFeedStore(pushLog);
-    // $params/$imageUrl tampoco entra a $home: no representa un recurso
-    // remoto en absoluto, es estado local derivado sincrónicamente.
-    const image = createImageParamsStore();
-    return { stores, retries, configs, $home, sse, feed, image };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [generation]);
-
-  useEffect(() => {
-    logRef.current?.scrollTo({ top: logRef.current.scrollHeight });
-  }, [log]);
-
-  const idleHome = useMemo(
-    () =>
-      Object.fromEntries(RESOURCE_DEFS.map((d) => [d.key, [true, null, null]])),
-    [],
-  );
-  const homeState = useGatedValue($home, active, idleHome);
-
-  const handleToggleSubscribe = () => {
-    setActive((prev) => {
-      const next = !prev;
-      pushLog(
-        next
-          ? "$home.subscribe() → primer subscriptor, se activa onMount de cada recurso"
-          : "$home unsubscribe → sin subscriptores, se limpia cada recurso",
-      );
-      return next;
-    });
-  };
-
-  const handleRemount = () => {
-    setActive(false);
-    setLog([]);
-    setGeneration((g) => g + 1);
-    pushLog("Stores recreados desde cero (simula recargar la página)");
-  };
+  // El único estado que vive en el padre: un contador para forzar un
+  // remount completo de cada tarjeta (cada una crea sus propios stores,
+  // su propio log y su propio "montado/desmontado" — nada se comparte).
+  const [resetKey, setResetKey] = useState(0);
 
   return (
     <div className="flex flex-col gap-6 rounded-xl border border-stone-200 bg-stone-50/50 p-4 sm:p-6">
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <div>
-          <p className="text-sm font-semibold text-stone-800">
-            $home = computed([$session, $recentArticles, $serverHealth])
-          </p>
-          <p className="text-xs text-stone-500">
-            Nada se pide hasta que alguien se suscribe a <code>$home</code>.
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          <button
-            onClick={handleRemount}
-            className="rounded-md border border-stone-300 bg-white px-3 py-1.5 text-xs font-medium text-stone-700 transition-colors hover:bg-stone-100"
-          >
-            Recargar página
-          </button>
-          <button
-            onClick={handleToggleSubscribe}
-            className={
-              "rounded-md px-3 py-1.5 text-xs font-semibold transition-colors " +
-              (active
-                ? "bg-stone-900 text-white hover:bg-stone-700"
-                : "bg-emerald-600 text-white hover:bg-emerald-500")
-            }
-          >
-            {active ? "Desmontar (unsubscribe)" : "Montar HomePage (subscribe)"}
-          </button>
-        </div>
+        <p className="text-xs text-stone-500">
+          Cada tarjeta de abajo es un ejemplo independiente: su propio botón
+          montar/desmontar, su propio registro de actividad, y su propio campo
+          con el último estado. Ninguna depende de que otra esté montada.
+        </p>
+        <button
+          onClick={() => setResetKey((k) => k + 1)}
+          className="shrink-0 rounded-md border border-stone-300 bg-white px-3 py-1.5 text-xs font-medium text-stone-700 transition-colors hover:bg-stone-100"
+        >
+          Reiniciar todos los ejemplos
+        </button>
       </div>
 
       <div className="grid gap-4 sm:grid-cols-3">
         {RESOURCE_DEFS.map((def) => (
-          <ResourceCard
-            key={`${def.key}-${generation}`}
-            def={def}
-            store={stores[def.key]}
-            config={configs[def.key]}
-            active={active}
-            onRetry={retries[def.key]}
-          />
+          <ResourceCard key={`${def.key}-${resetKey}`} def={def} />
         ))}
       </div>
 
@@ -846,13 +910,7 @@ export default function MyStateDemo() {
           <code>onUnmount</code>, un recurso que no se resuelve una sola vez
         </p>
         <div className="grid gap-4 sm:grid-cols-3">
-          <SseCard
-            key={`sse-${generation}`}
-            store={sse.$resource}
-            config={sse.config}
-            active={active}
-            onReconnect={sse.reconnect}
-          />
+          <SseCard key={`sse-${resetKey}`} />
         </div>
       </div>
 
@@ -862,13 +920,7 @@ export default function MyStateDemo() {
           el estado que permite continuar la paginación
         </p>
         <div className="grid gap-4 sm:grid-cols-3">
-          <FeedCard
-            key={`feed-${generation}`}
-            store={feed.$feed}
-            config={feed.config}
-            active={active}
-            onLoadMore={feed.loadMore}
-          />
+          <FeedCard key={`feed-${resetKey}`} />
         </div>
       </div>
 
@@ -877,42 +929,7 @@ export default function MyStateDemo() {
           Parámetros reactivos: <code>computed</code> sin <code>onMount</code>,
           no hay nada remoto que pedir perezosamente
         </p>
-        <ImageParamsCard
-          key={`image-${generation}`}
-          paramsStore={image.$params}
-          imageUrlStore={image.$imageUrl}
-        />
-      </div>
-
-      <div>
-        <p className="mb-1 text-xs font-medium text-stone-500">
-          Estado combinado de la página ($home.get())
-        </p>
-        <pre className="max-h-32 overflow-auto rounded-md bg-stone-900 p-3 text-[11px] leading-relaxed text-stone-100">
-          {JSON.stringify(homeState, null, 2)}
-        </pre>
-      </div>
-
-      <div>
-        <p className="mb-1 text-xs font-medium text-stone-500">
-          Registro de actividad (onMount / onStop / t())
-        </p>
-        <div
-          ref={logRef}
-          className="h-32 overflow-y-auto rounded-md border border-stone-200 bg-white p-2 font-mono text-[11px] leading-relaxed text-stone-600"
-        >
-          {log.length === 0 && (
-            <p className="text-stone-400">
-              Sin actividad todavía. Monta la página para ver los fetch
-              dispararse.
-            </p>
-          )}
-          {log.map((entry) => (
-            <p key={entry.id}>
-              <span className="text-stone-400">{entry.time}</span> {entry.text}
-            </p>
-          ))}
-        </div>
+        <ImageParamsCard key={`image-${resetKey}`} />
       </div>
     </div>
   );

--- a/src/pages/guides/index.astro
+++ b/src/pages/guides/index.astro
@@ -1,0 +1,72 @@
+---
+import DefaultLayout from "@/components/layouts/DefaultLayout.astro";
+import BlogHeader from "@/components/blog-header.astro";
+import Footer from "@/sections/footer.astro";
+
+export const prerender = true;
+
+const pageUrl = new URL("/guides", Astro.site || Astro.url.origin).href;
+
+type Guide = {
+  slug: string;
+  title: string;
+  description: string;
+};
+
+const guides: Guide[] = [
+  {
+    slug: "my-state-pattern",
+    title: "my-state pattern",
+    description:
+      "Patrón para modelar el estado de una página como un store de nanostores compuesto por recursos [loading, error, data], con demo interactiva: fetch, cancelación, SSE, infinite scroll y parámetros reactivos.",
+  },
+];
+---
+
+<DefaultLayout
+  title="Guías - Jonathan Delgado"
+  description="Guías técnicas sobre patrones y prácticas de desarrollo."
+  lang="es"
+>
+  <Fragment slot="head">
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content={pageUrl} />
+    <meta property="og:title" content="Guías - Jonathan Delgado" />
+    <meta
+      property="og:description"
+      content="Guías técnicas sobre patrones y prácticas de desarrollo."
+    />
+    <link rel="canonical" href={pageUrl} />
+  </Fragment>
+
+  <BlogHeader />
+
+  <main class="container mx-auto px-4 py-12 max-w-3xl">
+    <header class="mb-12">
+      <p class="text-sm font-medium text-stone-500 mb-2">Guías</p>
+      <h1 class="text-3xl sm:text-4xl font-bold text-stone-900 mb-4">
+        Guías técnicas
+      </h1>
+      <p class="text-stone-600 leading-relaxed">
+        Patrones y prácticas de desarrollo, explicados con ejemplos y demos
+        interactivas.
+      </p>
+    </header>
+
+    <div class="grid gap-4 sm:grid-cols-2">
+      {
+        guides.map((guide) => (
+          <a
+            href={`/guides/${guide.slug}`}
+            class="block rounded-lg border border-stone-200 bg-white p-4 transition-colors hover:bg-stone-50"
+          >
+            <h2 class="mb-1 font-semibold text-stone-900">{guide.title}</h2>
+            <p class="text-sm text-stone-600">{guide.description}</p>
+          </a>
+        ))
+      }
+    </div>
+  </main>
+
+  <Footer />
+</DefaultLayout>

--- a/src/pages/guides/my-state-pattern.astro
+++ b/src/pages/guides/my-state-pattern.astro
@@ -7,8 +7,10 @@ import MyStateDemo from "@/components/my-state-pattern/MyStateDemo.tsx";
 
 export const prerender = true;
 
-const pageUrl = new URL("/my-state-pattern", Astro.site || Astro.url.origin)
-  .href;
+const pageUrl = new URL(
+  "/guides/my-state-pattern",
+  Astro.site || Astro.url.origin,
+).href;
 
 const resourceTypeSnippet = `type Resource<T> = [loading: boolean, error: unknown, data: T | null]
 

--- a/src/pages/my-state-pattern.astro
+++ b/src/pages/my-state-pattern.astro
@@ -271,6 +271,175 @@ $home.listen((state) => {
 
     <section class="mb-12">
       <h2 class="text-xl font-semibold text-stone-900 mb-3">
+        Entidades del patrón
+      </h2>
+      <p class="text-stone-600 leading-relaxed mb-4">
+        Un mapa rápido de las piezas que aparecen en esta página, de la más
+        pequeña (una tupla) a la más compuesta (un store por página), con las
+        dos variantes que agregan un contrato distinto: cancelación, streaming y
+        paginación.
+      </p>
+      <div class="overflow-x-auto rounded-lg border border-stone-200">
+        <table class="w-full min-w-[640px] border-collapse text-sm">
+          <thead>
+            <tr class="border-b border-stone-200 bg-stone-50 text-left">
+              <th class="px-4 py-2 font-semibold text-stone-800">Entidad</th>
+              <th class="px-4 py-2 font-semibold text-stone-800">Forma</th>
+              <th class="px-4 py-2 font-semibold text-stone-800">Rol</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-stone-100 text-stone-600">
+            <tr>
+              <td class="px-4 py-3 align-top">
+                <a href="#resource" class="font-medium text-stone-900 underline"
+                  ><code>Resource&lt;T&gt;</code></a
+                >
+              </td>
+              <td class="px-4 py-3 align-top">
+                <code>[loading, error, data]</code>
+              </td>
+              <td class="px-4 py-3 align-top">
+                La unidad atómica de estado: cualquier recurso remoto de una
+                sola resolución sigue siempre esta forma.
+              </td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 align-top">
+                <a href="#t-helper" class="font-medium text-stone-900 underline"
+                  ><code>t(promise)</code></a
+                >
+              </td>
+              <td class="px-4 py-3 align-top">
+                <code>Promise&lt;T&gt; → [ok, error, data]</code>
+              </td>
+              <td class="px-4 py-3 align-top">
+                Adapta cualquier promesa a la forma que espera un{" "}
+                <code>Resource&lt;T&gt;</code>, sin <code>try/catch</code>{" "}
+                repetido y con <code>data</code> tipada según <code>ok</code>.
+              </td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 align-top">
+                <a
+                  href="#implementaciones"
+                  class="font-medium text-stone-900 underline"
+                  ><code>$resource</code> (atom)</a
+                >
+              </td>
+              <td class="px-4 py-3 align-top">
+                <code>atom&lt;Resource&lt;T&gt;&gt;([true, null, null])</code>
+              </td>
+              <td class="px-4 py-3 align-top">
+                El store nanostores de un recurso individual: nace en{" "}
+                <code>loading</code> y se actualiza con <code>set</code>.
+              </td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 align-top">
+                <a
+                  href="#implementaciones"
+                  class="font-medium text-stone-900 underline"
+                  ><code>onMount</code> / <code>onUnmount</code></a
+                >
+              </td>
+              <td class="px-4 py-3 align-top">
+                <code>onMount($store, () =&gt; cleanup)</code>
+              </td>
+              <td class="px-4 py-3 align-top">
+                El ciclo de vida completo: <code>onMount</code> corre al primer subscriptor
+                y dispara el fetch/stream/conexión; lo que retorna (el <strong
+                  >onUnmount</strong
+                >) corre al último subscriptor, con ~1s de gracia.
+              </td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 align-top">
+                <a
+                  href="#cancelacion"
+                  class="font-medium text-stone-900 underline"
+                  ><code>AbortController</code></a
+                >
+              </td>
+              <td class="px-4 py-3 align-top">
+                <code>signal</code> pasado al fetcher
+              </td>
+              <td class="px-4 py-3 align-top">
+                Cancela lo que esté en curso desde el <code>onUnmount</code>: un
+                fetch, un reintento, o la página en curso de un feed.
+              </td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 align-top">
+                <a
+                  href="#implementaciones"
+                  class="font-medium text-stone-900 underline"
+                  ><code>computed</code></a
+                >
+              </td>
+              <td class="px-4 py-3 align-top">
+                <code>computed([$a, $b, ...], combiner)</code>
+              </td>
+              <td class="px-4 py-3 align-top">
+                Compone varios <code>$resource</code> en un store derivado, propagando
+                la suscripción de forma transitiva a cada uno.
+              </td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 align-top">
+                <a href="#consumo" class="font-medium text-stone-900 underline"
+                  ><code>$home</code> / <code>HomeState</code></a
+                >
+              </td>
+              <td class="px-4 py-3 align-top">
+                <code>{"{"} session, recentArticles, ... {"}"}</code>
+              </td>
+              <td class="px-4 py-3 align-top">
+                El estado completo de una página: agrupa sus recursos bajo un
+                solo store, consumible con <code>useStore</code>{" "}
+                (React) o <code>subscribe</code>/<code>listen</code>{" "}
+                (vanilla).
+              </td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 align-top">
+                <a href="#sse" class="font-medium text-stone-900 underline"
+                  >Recurso en vivo (SSE)</a
+                >
+              </td>
+              <td class="px-4 py-3 align-top">
+                <code>onMessage / onError</code> repetidos
+              </td>
+              <td class="px-4 py-3 align-top">
+                Variante que llama <code>$resource.set(...)</code> muchas veces mientras
+                la conexión está abierta, en vez de resolver una promesa una sola
+                vez; el cleanup cierra la conexión (<code>close()</code>) en vez
+                de abortar un fetch.
+              </td>
+            </tr>
+            <tr>
+              <td class="px-4 py-3 align-top">
+                <a
+                  href="#infinite-scroll"
+                  class="font-medium text-stone-900 underline"
+                  ><code>FeedState&lt;T&gt;</code></a
+                >
+              </td>
+              <td class="px-4 py-3 align-top">
+                <code>{"{"} items, cursor, hasMore, loading, error {"}"}</code>
+              </td>
+              <td class="px-4 py-3 align-top">
+                Variante incremental para listas paginadas: cada página se
+                concatena en vez de reemplazar el valor, y el{" "}
+                <code>cursor</code> es el state que permite continuar la paginación.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section id="resource" class="mb-12">
+      <h2 class="text-xl font-semibold text-stone-900 mb-3">
         La tupla de estado
       </h2>
       <p class="text-stone-600 leading-relaxed mb-4">
@@ -280,7 +449,7 @@ $home.listen((state) => {
       <Code code={resourceTypeSnippet} lang="ts" theme="github-dark" />
     </section>
 
-    <section class="mb-12">
+    <section id="t-helper" class="mb-12">
       <h2 class="text-xl font-semibold text-stone-900 mb-3">
         El helper <code>t</code>: adiós al try/catch
       </h2>
@@ -293,7 +462,7 @@ $home.listen((state) => {
       <Code code={tHelperSnippet} lang="ts" theme="github-dark" />
     </section>
 
-    <section class="mb-12">
+    <section id="demo" class="mb-12">
       <h2 class="text-xl font-semibold text-stone-900 mb-3">
         Pruébalo: el patrón corriendo en vivo
       </h2>
@@ -314,7 +483,7 @@ $home.listen((state) => {
       <MyStateDemo client:load />
     </section>
 
-    <section class="mb-12">
+    <section id="implementaciones" class="mb-12">
       <h2 class="text-xl font-semibold text-stone-900 mb-3">
         Dos formas de implementarlo
       </h2>
@@ -344,7 +513,7 @@ $home.listen((state) => {
       </div>
     </section>
 
-    <section class="mb-12">
+    <section id="cancelacion" class="mb-12">
       <h2 class="text-xl font-semibold text-stone-900 mb-3">
         Cancelar el fetch en curso
       </h2>
@@ -373,7 +542,7 @@ $home.listen((state) => {
       </p>
     </section>
 
-    <section class="mb-12">
+    <section id="sse" class="mb-12">
       <h2 class="text-xl font-semibold text-stone-900 mb-3">
         Streaming con SSE: un recurso que no se resuelve una sola vez
       </h2>
@@ -400,7 +569,7 @@ $home.listen((state) => {
       </p>
     </section>
 
-    <section class="mb-12">
+    <section id="infinite-scroll" class="mb-12">
       <h2 class="text-xl font-semibold text-stone-900 mb-3">
         Infinite scroll: un store incremental
       </h2>
@@ -427,7 +596,7 @@ $home.listen((state) => {
       </p>
     </section>
 
-    <section class="mb-12">
+    <section id="consumo" class="mb-12">
       <h2 class="text-xl font-semibold text-stone-900 mb-3">Consumo</h2>
 
       <div class="mb-6">
@@ -446,7 +615,7 @@ $home.listen((state) => {
       </div>
     </section>
 
-    <section class="mb-12">
+    <section id="buenas-practicas" class="mb-12">
       <h2 class="text-xl font-semibold text-stone-900 mb-3">
         Buenas prácticas
       </h2>

--- a/src/pages/my-state-pattern.astro
+++ b/src/pages/my-state-pattern.astro
@@ -691,19 +691,23 @@ $home.listen((state) => {
         Pruébalo: el patrón corriendo en vivo
       </h2>
       <p class="text-stone-600 leading-relaxed mb-4">
-        La demo de abajo usa un store real de nanostores (variante atomizada)
-        con tres recursos simulados: <code>session</code>,{" "}
-        <code>recentArticles</code> y <code>serverHealth</code>. Móntalo para
-        ver el <code>onMount</code> disparar los fetch, fuerza un error en algún
-        recurso, o desmóntalo para ver el <code>onUnmount</code> abortando el fetch
-        en curso con <code>AbortController</code> (mira el registro de actividad).
-        También incluye <code>$liveMetrics</code>, un recurso que simula un{" "}
-        <code>EventSource</code> (SSE): en vez de resolver una vez, empuja mensajes
-        mientras está montado, y <code>onUnmount</code> cierra la conexión en vez
-        de abortar un fetch puntual. Y <code>$feed</code>, una lista con scroll
-        infinito real: desplázate dentro de la lista para pedir la siguiente
-        página automáticamente. Por último, <code>$imageUrl</code>: sin montar
-        nada, escribe un texto y mira la URL de un placeholder actualizarse
+        La demo de abajo usa stores reales de nanostores, y{" "}
+        <strong>cada tarjeta es un ejemplo independiente</strong>: tiene su
+        propio botón montar/desmontar, su propio registro de actividad, y su
+        propio campo con el último estado — montar una no dispara ni afecta a
+        las demás. <code>session</code>, <code>recentArticles</code>{" "}
+        y <code>serverHealth</code> son tres recursos simulados: móntalos para ver
+        <code>onMount</code> disparar el fetch, fuerza un error, o desmóntalos para
+        ver <code>onUnmount</code> abortando el fetch en curso con <code
+          >AbortController</code
+        >. <code>$liveMetrics</code>{" "}
+        simula un <code>EventSource</code> (SSE): en vez de resolver una vez, empuja
+        mensajes mientras está montado, y <code>onUnmount</code>{" "}
+        cierra la conexión en vez de abortar un fetch puntual.{" "}
+        <code>$feed</code> es una lista con scroll infinito real: desplázate dentro
+        de la lista para pedir la siguiente página automáticamente. Y <code
+          >$imageUrl</code
+        > no tiene mount: escribe un texto y mira la URL de un placeholder actualizarse
         sola.
       </p>
       <MyStateDemo client:load />
@@ -763,8 +767,8 @@ $home.listen((state) => {
         <code>signal.aborted</code> antes de aplicar el resultado: evita que la respuesta
         de un fetch ya cancelado sobrescriba un estado más reciente (por ejemplo,
         el de un reintento posterior). La demo de más arriba implementa exactamente
-        este patrón — desmóntala mientras un recurso está cargando y revisa el registro
-        de actividad.
+        este patrón — desmóntalo mientras un recurso está cargando y revisa su propio
+        registro de actividad.
       </p>
     </section>
 
@@ -790,8 +794,8 @@ $home.listen((state) => {
         va a leer — un leak silencioso y fácil de pasar por alto. La demo de
         arriba simula esto con{" "}
         <code>$liveMetrics</code>: móntala para ver los mensajes llegar cada
-        ~700ms, fuerza un corte de conexión, o desmóntala y revisa el registro
-        de actividad para confirmar el <code>source.close()</code>.
+        ~700ms, fuerza un corte de conexión, o desmóntala y revisa su propio
+        registro de actividad para confirmar el <code>source.close()</code>.
       </p>
     </section>
 

--- a/src/pages/my-state-pattern.astro
+++ b/src/pages/my-state-pattern.astro
@@ -197,6 +197,31 @@ const $feed = createFeedResource<Article>((cursor, signal) =>
   fetch(\`/api/articles?cursor=\${cursor ?? ""}\`, { signal }).then((r) => r.json()),
 )`;
 
+const reactiveParamsSnippet = `type ImageParams = {
+  text: string
+  width: number
+  height: number
+}
+
+const $params = atom<ImageParams>({ text: 'my-state', width: 320, height: 160 })
+
+// Un computed normal: no hay onMount, porque no hay nada async que
+// activar. La URL se recalcula sola cada vez que $params cambia.
+const $imageUrl = computed($params, (params) => {
+  const text = encodeURIComponent(params.text.trim() || ' ')
+  return \`https://placehold.co/\${params.width}x\${params.height}?text=\${text}\`
+})
+
+// En el componente: el <img> hace el "fetch" solo, declarativamente
+function PlaceholderPreview() {
+  const imageUrl = useStore($imageUrl)
+  return <img src={imageUrl} alt="preview" />
+}
+
+function onTextChange(text: string) {
+  $params.set({ ...$params.get(), text })
+}`;
+
 const reactSnippet = `import { useStore } from '@nanostores/react'
 
 function useHome() {
@@ -397,8 +422,35 @@ $home.listen((state) => {
         </a>
 
         <a
+          href="#parametros-reactivos"
+          class="block rounded-lg border border-stone-200 bg-white p-4 transition-colors hover:bg-stone-50"
+        >
+          <h3 class="mb-1 font-semibold text-stone-900">
+            Parámetros reactivos (imagen placeholder)
+          </h3>
+          <p class="mb-3 text-sm text-stone-600">
+            <code>$imageUrl</code>: estado local (un texto) que deriva una URL
+            de un servicio de placeholder, sin fetch propio ni onMount.
+          </p>
+          <div class="flex flex-wrap gap-1.5">
+            <span
+              class="rounded-full bg-stone-100 px-2 py-0.5 text-[11px] font-medium text-stone-600"
+              ><code>atom</code> de parámetros</span
+            >
+            <span
+              class="rounded-full bg-stone-100 px-2 py-0.5 text-[11px] font-medium text-stone-600"
+              ><code>computed</code> sin onMount</span
+            >
+            <span
+              class="rounded-full bg-stone-100 px-2 py-0.5 text-[11px] font-medium text-stone-600"
+              >derivación pura</span
+            >
+          </div>
+        </a>
+
+        <a
           href="#consumo"
-          class="block rounded-lg border border-stone-200 bg-white p-4 transition-colors hover:bg-stone-50 sm:col-span-2"
+          class="block rounded-lg border border-stone-200 bg-white p-4 transition-colors hover:bg-stone-50"
         >
           <h3 class="mb-1 font-semibold text-stone-900">Consumir el estado</h3>
           <p class="mb-3 text-sm text-stone-600">
@@ -587,6 +639,24 @@ $home.listen((state) => {
                 <code>cursor</code> es el state que permite continuar la paginación.
               </td>
             </tr>
+            <tr>
+              <td class="px-4 py-3 align-top">
+                <a
+                  href="#parametros-reactivos"
+                  class="font-medium text-stone-900 underline"
+                  ><code>ImageParams</code> / <code>$imageUrl</code></a
+                >
+              </td>
+              <td class="px-4 py-3 align-top">
+                <code>atom(params) → computed(url)</code>
+              </td>
+              <td class="px-4 py-3 align-top">
+                Estado local que no representa ningún recurso remoto:{" "}
+                <code>$params</code> guarda lo que el usuario escribe, y{" "}
+                <code>computed</code> deriva un valor sincrónicamente (una URL).
+                No necesita <code>onMount</code> porque no hay nada que activar perezosamente.
+              </td>
+            </tr>
           </tbody>
         </table>
       </div>
@@ -632,7 +702,9 @@ $home.listen((state) => {
         mientras está montado, y <code>onUnmount</code> cierra la conexión en vez
         de abortar un fetch puntual. Y <code>$feed</code>, una lista con scroll
         infinito real: desplázate dentro de la lista para pedir la siguiente
-        página automáticamente.
+        página automáticamente. Por último, <code>$imageUrl</code>: sin montar
+        nada, escribe un texto y mira la URL de un placeholder actualizarse
+        sola.
       </p>
       <MyStateDemo client:load />
     </section>
@@ -750,6 +822,41 @@ $home.listen((state) => {
       </p>
     </section>
 
+    <section id="parametros-reactivos" class="mb-12">
+      <h2 class="text-xl font-semibold text-stone-900 mb-3">
+        Parámetros reactivos: derivar sin fetch
+      </h2>
+      <p class="text-stone-600 leading-relaxed mb-4">
+        No todo el estado de una página viene de una API. A veces el "recurso"
+        es puramente local: un texto que el usuario escribe, y lo que necesitas
+        es <em>derivar</em> algo a partir de él — por ejemplo, la URL de una imagen
+        de un servicio de placeholder como{" "}
+        <a
+          href="https://placehold.co"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="underline hover:text-stone-900">placehold.co</a
+        >. Para eso no hace falta <code>Resource&lt;T&gt;</code> ni{" "}
+        <code>onMount</code>: alcanza con un <code>atom</code> de parámetros y un
+        <code>computed</code> que los transforma.
+      </p>
+      <Code code={reactiveParamsSnippet} lang="tsx" theme="github-dark" />
+      <p class="text-stone-600 leading-relaxed mt-3">
+        La diferencia clave con todo lo anterior: este <code>computed</code>{
+          " "
+        }
+        no necesita <code>onMount</code> porque no hay nada que activar perezosamente
+        — no se está pidiendo nada a un servidor, solo se está calculando un string
+        a partir de otro. El propio{" "}
+        <code>&lt;img src=&#123;imageUrl&#125;&gt;</code> es quien dispara la petición
+        de red, de forma declarativa, cuando el navegador decide pintar esa imagen.
+        La demo de arriba (<code>$imageUrl</code>) no necesita que montes nada:
+        escribe en el campo de texto y mira la URL (y la imagen) actualizarse
+        solas, con un pequeño debounce para no pedir una imagen nueva en cada
+        tecla.
+      </p>
+    </section>
+
     <section id="consumo" class="mb-12">
       <h2 class="text-xl font-semibold text-stone-900 mb-3">Consumo</h2>
 
@@ -795,6 +902,12 @@ $home.listen((state) => {
           Para listas paginadas usa un store que <em>acumule</em> items y guarde
           el cursor de la última página, no un{" "}
           <code>Resource&lt;T[]&gt;</code> que reemplaza el arreglo en cada fetch.
+        </li>
+        <li>
+          No fuerces <code>Resource&lt;T&gt;</code> ni <code>onMount</code>{" "}
+          en estado puramente local (parámetros de UI, filtros, texto de un input):
+          un <code>atom</code> + <code>computed</code> simple alcanza si no hay nada
+          async que activar perezosamente.
         </li>
         <li>
           Comparte recursos entre páginas con la variante atomizada cuando

--- a/src/pages/my-state-pattern.astro
+++ b/src/pages/my-state-pattern.astro
@@ -271,6 +271,160 @@ $home.listen((state) => {
 
     <section class="mb-12">
       <h2 class="text-xl font-semibold text-stone-900 mb-3">
+        Índice de soluciones
+      </h2>
+      <p class="text-stone-600 leading-relaxed mb-4">
+        Cada tarjeta es un caso de uso que la demo implementa de verdad, con los
+        patrones concretos que pone en juego. Es el mapa de "qué problema
+        resuelve esto" antes de bajar al detalle de cada uno.
+      </p>
+      <div class="grid gap-4 sm:grid-cols-2">
+        <a
+          href="#implementaciones"
+          class="block rounded-lg border border-stone-200 bg-white p-4 transition-colors hover:bg-stone-50"
+        >
+          <h3 class="mb-1 font-semibold text-stone-900">
+            Recurso remoto único
+          </h3>
+          <p class="mb-3 text-sm text-stone-600">
+            <code>session</code>, <code>recentArticles</code>,{" "}
+            <code>serverHealth</code>: un fetch que se resuelve una sola vez,
+            pedido perezosamente al primer subscriptor.
+          </p>
+          <div class="flex flex-wrap gap-1.5">
+            <span
+              class="rounded-full bg-stone-100 px-2 py-0.5 text-[11px] font-medium text-stone-600"
+              ><code>Resource&lt;T&gt;</code></span
+            >
+            <span
+              class="rounded-full bg-stone-100 px-2 py-0.5 text-[11px] font-medium text-stone-600"
+              ><code>t()</code></span
+            >
+            <span
+              class="rounded-full bg-stone-100 px-2 py-0.5 text-[11px] font-medium text-stone-600"
+              ><code>onMount</code> perezoso</span
+            >
+            <span
+              class="rounded-full bg-stone-100 px-2 py-0.5 text-[11px] font-medium text-stone-600"
+              ><code>computed</code></span
+            >
+          </div>
+        </a>
+
+        <a
+          href="#cancelacion"
+          class="block rounded-lg border border-stone-200 bg-white p-4 transition-colors hover:bg-stone-50"
+        >
+          <h3 class="mb-1 font-semibold text-stone-900">
+            Cancelar un fetch en curso
+          </h3>
+          <p class="mb-3 text-sm text-stone-600">
+            Abortar la petición cuando el último subscriptor se va, en vez de
+            solo ignorar una respuesta tardía.
+          </p>
+          <div class="flex flex-wrap gap-1.5">
+            <span
+              class="rounded-full bg-stone-100 px-2 py-0.5 text-[11px] font-medium text-stone-600"
+              ><code>onUnmount</code></span
+            >
+            <span
+              class="rounded-full bg-stone-100 px-2 py-0.5 text-[11px] font-medium text-stone-600"
+              ><code>AbortController</code></span
+            >
+            <span
+              class="rounded-full bg-stone-100 px-2 py-0.5 text-[11px] font-medium text-stone-600"
+              >reintento</span
+            >
+          </div>
+        </a>
+
+        <a
+          href="#sse"
+          class="block rounded-lg border border-stone-200 bg-white p-4 transition-colors hover:bg-stone-50"
+        >
+          <h3 class="mb-1 font-semibold text-stone-900">
+            Streaming en vivo (SSE)
+          </h3>
+          <p class="mb-3 text-sm text-stone-600">
+            <code>$liveMetrics</code>: un recurso que empuja datos repetidas
+            veces mientras la conexión está abierta, no una sola vez.
+          </p>
+          <div class="flex flex-wrap gap-1.5">
+            <span
+              class="rounded-full bg-stone-100 px-2 py-0.5 text-[11px] font-medium text-stone-600"
+              ><code>onMount</code> / <code>onUnmount</code></span
+            >
+            <span
+              class="rounded-full bg-stone-100 px-2 py-0.5 text-[11px] font-medium text-stone-600"
+              >recurso "en vivo"</span
+            >
+            <span
+              class="rounded-full bg-stone-100 px-2 py-0.5 text-[11px] font-medium text-stone-600"
+              ><code>EventSource</code></span
+            >
+          </div>
+        </a>
+
+        <a
+          href="#infinite-scroll"
+          class="block rounded-lg border border-stone-200 bg-white p-4 transition-colors hover:bg-stone-50"
+        >
+          <h3 class="mb-1 font-semibold text-stone-900">
+            Infinite scroll paginado
+          </h3>
+          <p class="mb-3 text-sm text-stone-600">
+            <code>$feed</code>: una lista que acumula items página a página,
+            retomando desde el cursor de la última.
+          </p>
+          <div class="flex flex-wrap gap-1.5">
+            <span
+              class="rounded-full bg-stone-100 px-2 py-0.5 text-[11px] font-medium text-stone-600"
+              ><code>FeedState&lt;T&gt;</code></span
+            >
+            <span
+              class="rounded-full bg-stone-100 px-2 py-0.5 text-[11px] font-medium text-stone-600"
+              >cursor</span
+            >
+            <span
+              class="rounded-full bg-stone-100 px-2 py-0.5 text-[11px] font-medium text-stone-600"
+              ><code>AbortController</code></span
+            >
+            <span
+              class="rounded-full bg-stone-100 px-2 py-0.5 text-[11px] font-medium text-stone-600"
+              ><code>onMount</code> condicional</span
+            >
+          </div>
+        </a>
+
+        <a
+          href="#consumo"
+          class="block rounded-lg border border-stone-200 bg-white p-4 transition-colors hover:bg-stone-50 sm:col-span-2"
+        >
+          <h3 class="mb-1 font-semibold text-stone-900">Consumir el estado</h3>
+          <p class="mb-3 text-sm text-stone-600">
+            El mismo store se lee igual desde React que desde JS vanilla, sin
+            cambiar la lógica de negocio.
+          </p>
+          <div class="flex flex-wrap gap-1.5">
+            <span
+              class="rounded-full bg-stone-100 px-2 py-0.5 text-[11px] font-medium text-stone-600"
+              ><code>useStore</code></span
+            >
+            <span
+              class="rounded-full bg-stone-100 px-2 py-0.5 text-[11px] font-medium text-stone-600"
+              ><code>subscribe</code></span
+            >
+            <span
+              class="rounded-full bg-stone-100 px-2 py-0.5 text-[11px] font-medium text-stone-600"
+              ><code>listen</code></span
+            >
+          </div>
+        </a>
+      </div>
+    </section>
+
+    <section class="mb-12">
+      <h2 class="text-xl font-semibold text-stone-900 mb-3">
         Entidades del patrón
       </h2>
       <p class="text-stone-600 leading-relaxed mb-4">

--- a/src/pages/my-state-pattern.astro
+++ b/src/pages/my-state-pattern.astro
@@ -222,6 +222,44 @@ function onTextChange(text: string) {
   $params.set({ ...$params.get(), text })
 }`;
 
+const reactiveSearchSnippet = `// Dos stores separados: $params no sabe nada de fetch, $search no
+// sabe nada de inputs. $search es el único con onMount.
+function createSearchStore() {
+  const $params = atom<string>('')
+  const $search = atom<Resource<Item[]>>([true, null, null])
+  let controller: AbortController | null = null
+
+  onMount($search, () => {
+    // subscribe (a diferencia de listen) también dispara con el valor
+    // ACTUAL de $params, así el primer fetch sale de inmediato al
+    // montar, igual que cualquier otro recurso — y sigue disparando
+    // con cada cambio posterior.
+    const unsubscribe = $params.subscribe((query) => {
+      controller?.abort()
+      controller = new AbortController()
+      $search.set([true, null, null])
+
+      t(searchItems(query, controller.signal)).then(([ok, error, data]) => {
+        if (controller.signal.aborted) return
+        $search.set(ok ? [false, null, data] : [false, error, null])
+      })
+    })
+
+    return () => {
+      unsubscribe()
+      controller?.abort()
+    }
+  })
+
+  return { $params, $search }
+}
+
+// En cualquier input de la app:
+const { $params, $search } = createSearchStore()
+function onQueryChange(query: string) {
+  $params.set(query) // $search reacciona solo, si está montado
+}`;
+
 const reactSnippet = `import { useStore } from '@nanostores/react'
 
 function useHome() {
@@ -426,11 +464,14 @@ $home.listen((state) => {
           class="block rounded-lg border border-stone-200 bg-white p-4 transition-colors hover:bg-stone-50"
         >
           <h3 class="mb-1 font-semibold text-stone-900">
-            Parámetros reactivos (imagen placeholder)
+            Parámetros reactivos (placeholder y búsqueda)
           </h3>
           <p class="mb-3 text-sm text-stone-600">
-            <code>$imageUrl</code>: estado local (un texto) que deriva una URL
-            de un servicio de placeholder, sin fetch propio ni onMount.
+            <code>$imageUrl</code> deriva una URL sin fetch ni onMount;{" "}
+            <code>$search</code> reacciona a cambios de <code>$params</code>{
+              " "
+            }
+            con un fetch cancelable cada vez.
           </p>
           <div class="flex flex-wrap gap-1.5">
             <span
@@ -443,7 +484,11 @@ $home.listen((state) => {
             >
             <span
               class="rounded-full bg-stone-100 px-2 py-0.5 text-[11px] font-medium text-stone-600"
-              >derivación pura</span
+              ><code>subscribe()</code> dentro de onMount</span
+            >
+            <span
+              class="rounded-full bg-stone-100 px-2 py-0.5 text-[11px] font-medium text-stone-600"
+              ><code>AbortController</code></span
             >
           </div>
         </a>
@@ -657,6 +702,25 @@ $home.listen((state) => {
                 No necesita <code>onMount</code> porque no hay nada que activar perezosamente.
               </td>
             </tr>
+            <tr>
+              <td class="px-4 py-3 align-top">
+                <a
+                  href="#parametros-reactivos"
+                  class="font-medium text-stone-900 underline"
+                  ><code>$params</code> / <code>$search</code></a
+                >
+              </td>
+              <td class="px-4 py-3 align-top">
+                <code>atom(string) + onMount(subscribe)</code>
+              </td>
+              <td class="px-4 py-3 align-top">
+                Dos stores separados en vez de uno: <code>$params</code> no sabe
+                nada de fetch, <code>$search</code> es el único con{" "}
+                <code>onMount</code> y se <code>subscribe()</code> a{" "}
+                <code>$params</code> al montarse, disparando un fetch cancelable
+                en el primer valor y en cada cambio posterior.
+              </td>
+            </tr>
           </tbody>
         </table>
       </div>
@@ -705,10 +769,12 @@ $home.listen((state) => {
         mensajes mientras está montado, y <code>onUnmount</code>{" "}
         cierra la conexión en vez de abortar un fetch puntual.{" "}
         <code>$feed</code> es una lista con scroll infinito real: desplázate dentro
-        de la lista para pedir la siguiente página automáticamente. Y <code
+        de la lista para pedir la siguiente página automáticamente. <code
           >$imageUrl</code
         > no tiene mount: escribe un texto y mira la URL de un placeholder actualizarse
-        sola.
+        sola. Y <code>$search</code> sí lo tiene: móntalo para ver el primer fetch
+        salir con el valor actual de <code>$params</code>, y escribe para ver
+        cada búsqueda cancelar la anterior.
       </p>
       <MyStateDemo client:load />
     </section>
@@ -828,37 +894,75 @@ $home.listen((state) => {
 
     <section id="parametros-reactivos" class="mb-12">
       <h2 class="text-xl font-semibold text-stone-900 mb-3">
-        Parámetros reactivos: derivar sin fetch
+        Parámetros reactivos: derivar sin fetch, o reaccionar con uno
       </h2>
       <p class="text-stone-600 leading-relaxed mb-4">
         No todo el estado de una página viene de una API. A veces el "recurso"
-        es puramente local: un texto que el usuario escribe, y lo que necesitas
-        es <em>derivar</em> algo a partir de él — por ejemplo, la URL de una imagen
-        de un servicio de placeholder como{" "}
-        <a
-          href="https://placehold.co"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="underline hover:text-stone-900">placehold.co</a
-        >. Para eso no hace falta <code>Resource&lt;T&gt;</code> ni{" "}
-        <code>onMount</code>: alcanza con un <code>atom</code> de parámetros y un
-        <code>computed</code> que los transforma.
+        es puramente local: un texto que el usuario escribe. Lo que hagas con
+        ese texto define el patrón — y hay dos casos bien distintos.
       </p>
-      <Code code={reactiveParamsSnippet} lang="tsx" theme="github-dark" />
-      <p class="text-stone-600 leading-relaxed mt-3">
-        La diferencia clave con todo lo anterior: este <code>computed</code>{
-          " "
-        }
-        no necesita <code>onMount</code> porque no hay nada que activar perezosamente
-        — no se está pidiendo nada a un servidor, solo se está calculando un string
-        a partir de otro. El propio{" "}
-        <code>&lt;img src=&#123;imageUrl&#125;&gt;</code> es quien dispara la petición
-        de red, de forma declarativa, cuando el navegador decide pintar esa imagen.
-        La demo de arriba (<code>$imageUrl</code>) no necesita que montes nada:
-        escribe en el campo de texto y mira la URL (y la imagen) actualizarse
-        solas, con un pequeño debounce para no pedir una imagen nueva en cada
-        tecla.
-      </p>
+
+      <div class="mb-6">
+        <h3 class="text-base font-semibold text-stone-800 mb-2">
+          Derivar sin fetch: <code>computed</code> sin <code>onMount</code>
+        </h3>
+        <p class="text-stone-600 leading-relaxed mb-3">
+          Cuando solo necesitas <em>transformar</em> el parámetro — por ejemplo,
+          armar la URL de una imagen de un servicio de placeholder como{" "}
+          <a
+            href="https://placehold.co"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="underline hover:text-stone-900">placehold.co</a
+          > — no hace falta <code>Resource&lt;T&gt;</code> ni{" "}
+          <code>onMount</code>: alcanza con un <code>atom</code> de parámetros y
+          un <code>computed</code> que los transforma.
+        </p>
+        <Code code={reactiveParamsSnippet} lang="tsx" theme="github-dark" />
+        <p class="text-stone-600 leading-relaxed mt-3">
+          Este <code>computed</code> no necesita <code>onMount</code> porque no hay
+          nada que activar perezosamente — no se está pidiendo nada a un servidor,
+          solo se está calculando un string a partir de otro. El propio <code
+            >&lt;img src=&#123;imageUrl&#125;&gt;</code
+          > es quien dispara la petición de red, de forma declarativa, cuando el
+          navegador decide pintar esa imagen. La demo de arriba (<code
+            >$imageUrl</code
+          >) no necesita que montes nada: escribe en el campo de texto y mira la
+          URL (y la imagen) actualizarse solas.
+        </p>
+      </div>
+
+      <div>
+        <h3 class="text-base font-semibold text-stone-800 mb-2">
+          Reaccionar con un fetch: dos stores, uno con <code>onMount</code>
+        </h3>
+        <p class="text-stone-600 leading-relaxed mb-3">
+          Cuando el parámetro sí necesita pedir algo remoto — una búsqueda que
+          se dispara mientras escribes — el patrón es más simple de lo que
+          parece: <code>$params</code> guarda el texto y no sabe nada de fetch; <code
+            >$search</code
+          > es el único store con{" "}
+          <code>onMount</code>, y al montarse se subscribe a{" "}
+          <code>$params</code> con <code>subscribe()</code> (no{" "}
+          <code>listen()</code>) para que el primer fetch salga de inmediato con
+          el valor actual, igual que cualquier otro recurso de la página.
+        </p>
+        <Code code={reactiveSearchSnippet} lang="tsx" theme="github-dark" />
+        <p class="text-stone-600 leading-relaxed mt-3">
+          Cada cambio en <code>$params</code> vuelve a ejecutar el callback del <code
+            >subscribe</code
+          >, que aborta el fetch anterior antes de lanzar el nuevo — el mismo <code
+            >AbortController</code
+          > de la sección de cancelación, aplicado a una petición que se repite en
+          vez de una que solo pasa una vez. La demo de arriba (<code
+            >$search</code
+          >) es independiente como las demás: móntala para ver el primer fetch
+          salir solo, escribe para ver cada tecla (con debounce) cancelar y
+          relanzar la búsqueda, y desmóntala para ver el{" "}
+          <code>onUnmount</code> hacer <code>unsubscribe</code> de{" "}
+          <code>$params</code> además de abortar.
+        </p>
+      </div>
     </section>
 
     <section id="consumo" class="mb-12">

--- a/src/pages/my-state-pattern.astro
+++ b/src/pages/my-state-pattern.astro
@@ -1,0 +1,277 @@
+---
+import { Code } from "astro:components";
+import DefaultLayout from "@/components/layouts/DefaultLayout.astro";
+import BlogHeader from "@/components/blog-header.astro";
+import Footer from "@/sections/footer.astro";
+import MyStateDemo from "@/components/my-state-pattern/MyStateDemo.tsx";
+
+export const prerender = true;
+
+const pageUrl = new URL("/my-state-pattern", Astro.site || Astro.url.origin)
+  .href;
+
+const resourceTypeSnippet = `type Resource<T> = [loading: boolean, error: unknown, data: T | null]
+
+type HomeState = {
+  session: Resource<SessionData>
+  recentArticles: Resource<Article[]>
+  serverHealth: Resource<HealthData>
+}`;
+
+const tHelperSnippet = `const t = async <T>(
+  promise: Promise<T>,
+): Promise<[ok: true, error: null, data: T] | [ok: false, error: unknown, data: null]> => {
+  try {
+    const data = await promise
+    return [true, null, data]
+  } catch (error) {
+    return [false, error, null]
+  }
+}`;
+
+const monolithicSnippet = `import { atom, onMount } from 'nanostores'
+
+const $home = atom<HomeState>({
+  session: [true, null, null],
+  recentArticles: [true, null, null],
+  serverHealth: [true, null, null],
+})
+
+onMount($home, () => {
+  fetchSession()
+  fetchRecentArticles()
+  fetchServerHealth()
+
+  async function fetchSession() {
+    const [, error, data] = await t(fetch('/api/session').then((r) => r.json()))
+    $home.set({ ...$home.get(), session: [false, error, data] })
+  }
+
+  async function fetchRecentArticles() {
+    const [, error, data] = await t(fetch('/api/articles/recent').then((r) => r.json()))
+    $home.set({ ...$home.get(), recentArticles: [false, error, data] })
+  }
+
+  async function fetchServerHealth() {
+    const [, error, data] = await t(fetch('/api/health').then((r) => r.json()))
+    $home.set({ ...$home.get(), serverHealth: [false, error, data] })
+  }
+})`;
+
+const atomizedSnippet = `import { atom, onMount, computed } from 'nanostores'
+
+function createResource<T>(fetcher: () => Promise<T>) {
+  const $resource = atom<Resource<T>>([true, null, null])
+
+  onMount($resource, () => {
+    t(fetcher()).then(([, error, data]) => {
+      $resource.set([false, error, data])
+    })
+  })
+
+  return $resource
+}
+
+const $session = createResource(() => fetch('/api/session').then((r) => r.json()))
+const $recentArticles = createResource(() => fetch('/api/articles/recent').then((r) => r.json()))
+const $serverHealth = createResource(() => fetch('/api/health').then((r) => r.json()))
+
+const $home = computed(
+  [$session, $recentArticles, $serverHealth],
+  (session, recentArticles, serverHealth) => ({ session, recentArticles, serverHealth }),
+)`;
+
+const reactSnippet = `import { useStore } from '@nanostores/react'
+
+function useHome() {
+  return useStore($home)
+}
+
+function HomePage() {
+  const { session, recentArticles, serverHealth } = useHome()
+  const [sessionLoading, sessionError, sessionData] = session
+
+  if (sessionLoading) return <Spinner />
+  if (sessionError) return <ErrorBanner error={sessionError} />
+
+  return (
+    <div>
+      <UserBadge session={sessionData} />
+      <RecentArticlesList state={recentArticles} />
+      <ServerHealthIndicator state={serverHealth} />
+    </div>
+  )
+}`;
+
+const vanillaSnippet = `// subscribe: dispara inmediatamente con el valor actual, y luego con cada cambio
+$home.subscribe((state) => {
+  render(state)
+})
+
+// listen: solo dispara con cambios futuros, no con el valor actual
+$home.listen((state) => {
+  console.log('state changed', state)
+})`;
+---
+
+<DefaultLayout
+  title="my-state pattern — demo interactiva | Jonathan Delgado"
+  description="Demo interactiva del patrón my-state: modela el estado de una página como un store de nanostores compuesto por recursos [loading, error, data]."
+  lang="es"
+>
+  <Fragment slot="head">
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content={pageUrl} />
+    <meta property="og:title" content="my-state pattern — demo interactiva" />
+    <meta
+      property="og:description"
+      content="Demo interactiva del patrón my-state con nanostores: tuplas [loading, error, data], el helper t() y la pereza de onMount."
+    />
+    <link rel="canonical" href={pageUrl} />
+  </Fragment>
+
+  <BlogHeader />
+
+  <main class="container mx-auto px-4 py-12 max-w-3xl">
+    <header class="mb-12">
+      <p class="text-sm font-medium text-stone-500 mb-2">Patrón · nanostores</p>
+      <h1 class="text-3xl sm:text-4xl font-bold text-stone-900 mb-4">
+        my-state: un patrón para gestionar el estado de tus páginas
+      </h1>
+      <p class="text-stone-600 leading-relaxed">
+        Modela el estado de una página como <strong
+          >un único store compuesto por recurso</strong
+        >, donde cada recurso remoto sigue siempre la misma forma: una tupla <code
+          >[loading, error, data]</code
+        >. Esta página resume la idea y trae una demo interactiva que corre el
+        patrón de verdad, con <a
+          href="https://github.com/nanostores/nanostores"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="underline hover:text-stone-900">nanostores</a
+        >.
+      </p>
+    </header>
+
+    <section class="mb-12">
+      <h2 class="text-xl font-semibold text-stone-900 mb-3">
+        La tupla de estado
+      </h2>
+      <p class="text-stone-600 leading-relaxed mb-4">
+        Cada recurso remoto se representa con el mismo tipo, y el estado de la
+        página agrupa una tupla por cada sección de información que necesita:
+      </p>
+      <Code code={resourceTypeSnippet} lang="ts" theme="github-dark" />
+    </section>
+
+    <section class="mb-12">
+      <h2 class="text-xl font-semibold text-stone-900 mb-3">
+        El helper <code>t</code>: adiós al try/catch
+      </h2>
+      <p class="text-stone-600 leading-relaxed mb-4">
+        <code>t</code> envuelve cualquier promesa en una tupla{" "}
+        <code>[ok, error, data]</code> tipada como unión discriminada, así TypeScript
+        acota el tipo de <code>data</code> según el valor de{" "}
+        <code>ok</code>, sin <code>as</code> ni chequeos extra.
+      </p>
+      <Code code={tHelperSnippet} lang="ts" theme="github-dark" />
+    </section>
+
+    <section class="mb-12">
+      <h2 class="text-xl font-semibold text-stone-900 mb-3">
+        Pruébalo: el patrón corriendo en vivo
+      </h2>
+      <p class="text-stone-600 leading-relaxed mb-4">
+        La demo de abajo usa un store real de nanostores (variante atomizada)
+        con tres recursos simulados: <code>session</code>,{" "}
+        <code>recentArticles</code> y <code>serverHealth</code>. Móntalo para
+        ver el <code>onMount</code> disparar los fetch, fuerza un error en algún
+        recurso, o desmóntalo para ver la limpieza.
+      </p>
+      <MyStateDemo client:load />
+    </section>
+
+    <section class="mb-12">
+      <h2 class="text-xl font-semibold text-stone-900 mb-3">
+        Dos formas de implementarlo
+      </h2>
+
+      <div class="mb-6">
+        <h3 class="text-base font-semibold text-stone-800 mb-2">
+          Monolítico: un atom, un <code>onMount</code>
+        </h3>
+        <p class="text-stone-600 leading-relaxed mb-3">
+          Ideal cuando la página es simple y no necesitas reutilizar la lógica
+          de fetch en otra parte de la app.
+        </p>
+        <Code code={monolithicSnippet} lang="ts" theme="github-dark" />
+      </div>
+
+      <div>
+        <h3 class="text-base font-semibold text-stone-800 mb-2">
+          Atomizado: un recurso, un atom, compuestos con <code>computed</code>
+        </h3>
+        <p class="text-stone-600 leading-relaxed mb-3">
+          Cuando varias páginas comparten recursos (como <code>session</code>),
+          cada uno vive en su propio store reutilizable y se compone con{" "}
+          <code>computed</code>, que propaga la suscripción de forma transitiva:
+          la demo de arriba usa esta variante.
+        </p>
+        <Code code={atomizedSnippet} lang="ts" theme="github-dark" />
+      </div>
+    </section>
+
+    <section class="mb-12">
+      <h2 class="text-xl font-semibold text-stone-900 mb-3">Consumo</h2>
+
+      <div class="mb-6">
+        <h3 class="text-base font-semibold text-stone-800 mb-2">React</h3>
+        <Code code={reactSnippet} lang="tsx" theme="github-dark" />
+      </div>
+
+      <div>
+        <h3 class="text-base font-semibold text-stone-800 mb-2">JS vanilla</h3>
+        <p class="text-stone-600 leading-relaxed mb-3">
+          Usa <code>subscribe</code> si necesitas pintar el estado inicial (aunque
+          sea "cargando"); usa <code>listen</code> si solo te interesa reaccionar
+          a cambios posteriores.
+        </p>
+        <Code code={vanillaSnippet} lang="ts" theme="github-dark" />
+      </div>
+    </section>
+
+    <section class="mb-12">
+      <h2 class="text-xl font-semibold text-stone-900 mb-3">
+        Buenas prácticas
+      </h2>
+      <ul
+        class="list-disc list-inside space-y-2 text-stone-600 leading-relaxed"
+      >
+        <li>
+          Nombra los stores por página o feature (<code>$home</code>,{" "}
+          <code>$profile</code>, <code>$checkout</code>), no genéricamente.
+        </li>
+        <li>
+          Nunca mutes el objeto de estado: siempre <code>set</code> con uno nuevo.
+        </li>
+        <li>
+          Tipa la tupla de estado y desestructura con nombres para legibilidad.
+        </li>
+        <li>
+          Considera cancelar el fetch en curso si el store se desmonta antes de
+          que termine.
+        </li>
+        <li>
+          Comparte recursos entre páginas con la variante atomizada cuando
+          detectes duplicación.
+        </li>
+        <li>
+          Usa <code>t</code> para resolver promesas en cualquier punto de la app,
+          no solo dentro de <code>onMount</code>.
+        </li>
+      </ul>
+    </section>
+  </main>
+
+  <Footer />
+</DefaultLayout>

--- a/src/pages/my-state-pattern.astro
+++ b/src/pages/my-state-pattern.astro
@@ -134,6 +134,69 @@ const $liveMetrics = createLiveResource<Metrics>((onMessage, onError) => {
   return () => source.close()
 })`;
 
+const infiniteScrollSnippet = `type Page<T> = { items: T[]; nextCursor: string | null }
+
+type FeedState<T> = {
+  items: T[]
+  cursor: string | null
+  hasMore: boolean
+  loading: boolean
+  error: unknown
+}
+
+function createFeedResource<T>(
+  fetchPage: (cursor: string | null, signal: AbortSignal) => Promise<Page<T>>,
+) {
+  const $feed = atom<FeedState<T>>({
+    items: [],
+    cursor: null,
+    hasMore: true,
+    loading: true,
+    error: null,
+  })
+  let controller: AbortController | null = null
+
+  function loadPage(cursor: string | null) {
+    controller?.abort()
+    controller = new AbortController()
+    const { signal } = controller
+    $feed.set({ ...$feed.get(), loading: true, error: null })
+
+    t(fetchPage(cursor, signal)).then(([ok, error, page]) => {
+      if (signal.aborted) return
+      const prev = $feed.get()
+      $feed.set(
+        ok
+          ? {
+              items: [...prev.items, ...page.items], // se concatena, no se reemplaza
+              cursor: page.nextCursor,
+              hasMore: page.nextCursor !== null,
+              loading: false,
+              error: null,
+            }
+          : { ...prev, loading: false, error },
+      )
+    })
+  }
+
+  onMount($feed, () => {
+    // un remount rápido no debería tirar los items ya acumulados
+    if ($feed.get().items.length === 0) loadPage(null)
+    return () => controller?.abort()
+  })
+
+  function loadMore() {
+    const { cursor, hasMore, loading } = $feed.get()
+    if (hasMore && !loading) loadPage(cursor)
+  }
+
+  return { $feed, loadMore }
+}
+
+const $feed = createFeedResource<Article>((cursor, signal) =>
+  fetch(\`/api/articles?cursor=\${cursor ?? ""}\`, { signal }).then((r) => r.json()),
+)`;
+
 const reactSnippet = `import { useStore } from '@nanostores/react'
 
 function useHome() {
@@ -244,7 +307,9 @@ $home.listen((state) => {
         También incluye <code>$liveMetrics</code>, un recurso que simula un{" "}
         <code>EventSource</code> (SSE): en vez de resolver una vez, empuja mensajes
         mientras está montado, y <code>onUnmount</code> cierra la conexión en vez
-        de abortar un fetch puntual.
+        de abortar un fetch puntual. Y <code>$feed</code>, una lista con scroll
+        infinito real: desplázate dentro de la lista para pedir la siguiente
+        página automáticamente.
       </p>
       <MyStateDemo client:load />
     </section>
@@ -336,6 +401,33 @@ $home.listen((state) => {
     </section>
 
     <section class="mb-12">
+      <h2 class="text-xl font-semibold text-stone-900 mb-3">
+        Infinite scroll: un store incremental
+      </h2>
+      <p class="text-stone-600 leading-relaxed mb-4">
+        Una lista paginada tampoco encaja en <code>Resource&lt;T&gt;</code>{" "}
+        tal cual: cada página no reemplaza el estado, lo <strong>acumula</strong
+        >. El "state para continuar la paginación" es el <code>cursor</code> que
+        trae cada respuesta — no un número de página que vos llevas aparte, sino
+        el que el servidor te devuelve para pedir la siguiente tanda.
+      </p>
+      <Code code={infiniteScrollSnippet} lang="ts" theme="github-dark" />
+      <p class="text-stone-600 leading-relaxed mt-3">
+        Dos detalles que distinguen este store de los anteriores: primero, cada
+        página se concatena (<code>[...prev.items, ...page.items]</code>) en vez
+        de reemplazar el valor completo. Segundo, <code>onMount</code> solo pide
+        la primera página <em>si todavía no hay items</em> — así un remount rápido
+        (por ejemplo, volver a una lista que ya habías scrolleado) no descarta el
+        progreso ya cargado; simplemente retoma. <code>onUnmount</code> sigue cancelando
+        la página en curso con <code>AbortController</code>, igual que en el
+        ejemplo de arriba, pero sin tocar los items ya acumulados. La demo
+        simula un feed de 20 artículos en 4 páginas: móntala y desplázate dentro
+        de{" "}
+        <code>$feed</code> para ver la carga automática, o usa "Cargar más" directamente.
+      </p>
+    </section>
+
+    <section class="mb-12">
       <h2 class="text-xl font-semibold text-stone-900 mb-3">Consumo</h2>
 
       <div class="mb-6">
@@ -375,6 +467,11 @@ $home.listen((state) => {
           Cancela el fetch en curso desde el <code>onUnmount</code> (lo que retorna
           <code>onMount</code>) con un <code>AbortController</code>, no solo con
           una bandera que ignore la respuesta.
+        </li>
+        <li>
+          Para listas paginadas usa un store que <em>acumule</em> items y guarde
+          el cursor de la última página, no un{" "}
+          <code>Resource&lt;T[]&gt;</code> que reemplaza el arreglo en cada fetch.
         </li>
         <li>
           Comparte recursos entre páginas con la variante atomizada cuando

--- a/src/pages/my-state-pattern.astro
+++ b/src/pages/my-state-pattern.astro
@@ -81,6 +81,31 @@ const $home = computed(
   (session, recentArticles, serverHealth) => ({ session, recentArticles, serverHealth }),
 )`;
 
+const cancellationSnippet = `function createResource<T>(fetcher: (signal: AbortSignal) => Promise<T>) {
+  const $resource = atom<Resource<T>>([true, null, null])
+
+  onMount($resource, () => {
+    const controller = new AbortController()
+
+    t(fetcher(controller.signal)).then(([, error, data]) => {
+      // el controller ya fue abortado: no pises un estado más nuevo
+      // con la respuesta de un fetch que ya no nos interesa
+      if (controller.signal.aborted) return
+      $resource.set([false, error, data])
+    })
+
+    // esto es el "onUnmount": nanostores lo llama cuando el último
+    // subscriptor se va (con ~1s de gracia por si vuelve a montar)
+    return () => controller.abort()
+  })
+
+  return $resource
+}
+
+const $session = createResource((signal) =>
+  fetch('/api/session', { signal }).then((r) => r.json()),
+)`;
+
 const reactSnippet = `import { useStore } from '@nanostores/react'
 
 function useHome() {
@@ -186,7 +211,8 @@ $home.listen((state) => {
         con tres recursos simulados: <code>session</code>,{" "}
         <code>recentArticles</code> y <code>serverHealth</code>. Móntalo para
         ver el <code>onMount</code> disparar los fetch, fuerza un error en algún
-        recurso, o desmóntalo para ver la limpieza.
+        recurso, o desmóntalo para ver el <code>onUnmount</code> abortando el fetch
+        en curso con <code>AbortController</code> (mira el registro de actividad).
       </p>
       <MyStateDemo client:load />
     </section>
@@ -219,6 +245,35 @@ $home.listen((state) => {
         </p>
         <Code code={atomizedSnippet} lang="ts" theme="github-dark" />
       </div>
+    </section>
+
+    <section class="mb-12">
+      <h2 class="text-xl font-semibold text-stone-900 mb-3">
+        Cancelar el fetch en curso
+      </h2>
+      <p class="text-stone-600 leading-relaxed mb-4">
+        <code>onMount</code> puede devolver una función: nanostores la registra como
+        <strong>onUnmount</strong> y la ejecuta cuando el último subscriptor se va
+        (con un pequeño margen para no cancelar por un remount inmediato). Ese es
+        el lugar correcto para cancelar cualquier petición en curso: crea el <code
+          >AbortController</code
+        >{" "}
+        dentro del propio <code>onMount</code>, pásale su <code>signal</code>{
+          " "
+        }
+        al fetcher, y llama <code>controller.abort()</code> en el cleanup.
+      </p>
+      <Code code={cancellationSnippet} lang="ts" theme="github-dark" />
+      <p class="text-stone-600 leading-relaxed mt-3">
+        Al abortar, <code>fetch</code> rechaza la promesa con un{" "}
+        <code>AbortError</code>, que <code>t</code> captura igual que cualquier otro
+        error. Por eso conviene revisar{" "}
+        <code>signal.aborted</code> antes de aplicar el resultado: evita que la respuesta
+        de un fetch ya cancelado sobrescriba un estado más reciente (por ejemplo,
+        el de un reintento posterior). La demo de más arriba implementa exactamente
+        este patrón — desmóntala mientras un recurso está cargando y revisa el registro
+        de actividad.
+      </p>
     </section>
 
     <section class="mb-12">
@@ -258,8 +313,9 @@ $home.listen((state) => {
           Tipa la tupla de estado y desestructura con nombres para legibilidad.
         </li>
         <li>
-          Considera cancelar el fetch en curso si el store se desmonta antes de
-          que termine.
+          Cancela el fetch en curso desde el <code>onUnmount</code> (lo que retorna
+          <code>onMount</code>) con un <code>AbortController</code>, no solo con
+          una bandera que ignore la respuesta.
         </li>
         <li>
           Comparte recursos entre páginas con la variante atomizada cuando

--- a/src/pages/my-state-pattern.astro
+++ b/src/pages/my-state-pattern.astro
@@ -134,67 +134,66 @@ const $liveMetrics = createLiveResource<Metrics>((onMessage, onError) => {
   return () => source.close()
 })`;
 
-const infiniteScrollSnippet = `type Page<T> = { items: T[]; nextCursor: string | null }
-
-type FeedState<T> = {
-  items: T[]
-  cursor: string | null
-  hasMore: boolean
-  loading: boolean
-  error: unknown
-}
+const infiniteScrollSnippet = `// Mismo patrón que $params/$search: dos stores separados. $cursor no
+// sabe nada de fetch, $feed es el único con onMount y se subscribe a
+// $cursor al montarse — la diferencia es que la respuesta se concatena
+// a los items que ya había, en vez de reemplazarlos.
+type Page<T> = { items: T[]; hasMore: boolean }
+type FeedState<T> = { items: T[]; hasMore: boolean; loading: boolean; error: unknown }
 
 function createFeedResource<T>(
-  fetchPage: (cursor: string | null, signal: AbortSignal) => Promise<Page<T>>,
+  fetchPage: (cursor: number, signal: AbortSignal) => Promise<Page<T>>,
 ) {
-  const $feed = atom<FeedState<T>>({
-    items: [],
-    cursor: null,
-    hasMore: true,
-    loading: true,
-    error: null,
-  })
+  const $cursor = atom<number>(0)
+  const $feed = atom<FeedState<T>>({ items: [], hasMore: true, loading: true, error: null })
   let controller: AbortController | null = null
-
-  function loadPage(cursor: string | null) {
-    controller?.abort()
-    controller = new AbortController()
-    const { signal } = controller
-    $feed.set({ ...$feed.get(), loading: true, error: null })
-
-    t(fetchPage(cursor, signal)).then(([ok, error, page]) => {
-      if (signal.aborted) return
-      const prev = $feed.get()
-      $feed.set(
-        ok
-          ? {
-              items: [...prev.items, ...page.items], // se concatena, no se reemplaza
-              cursor: page.nextCursor,
-              hasMore: page.nextCursor !== null,
-              loading: false,
-              error: null,
-            }
-          : { ...prev, loading: false, error },
-      )
-    })
-  }
+  let lastFetchedCursor: number | null = null
 
   onMount($feed, () => {
-    // un remount rápido no debería tirar los items ya acumulados
-    if ($feed.get().items.length === 0) loadPage(null)
-    return () => controller?.abort()
+    // subscribe() dispara también con el valor actual de $cursor (0), así
+    // la primera página sale de inmediato al montar. Un remount rápido
+    // vuelve a disparar con el mismo cursor de la última vez: el guard
+    // evita repetir esa página y descartar los items ya acumulados.
+    const unsubscribe = $cursor.subscribe((cursor) => {
+      if (cursor === lastFetchedCursor) return
+      lastFetchedCursor = cursor
+
+      controller?.abort()
+      controller = new AbortController()
+      $feed.set({ ...$feed.get(), loading: true, error: null })
+
+      t(fetchPage(cursor, controller.signal)).then(([ok, error, page]) => {
+        if (controller.signal.aborted) return
+        const prev = $feed.get()
+        $feed.set(
+          ok
+            ? {
+                items: [...prev.items, ...page.items], // se concatena, no se reemplaza
+                hasMore: page.hasMore,
+                loading: false,
+                error: null,
+              }
+            : { ...prev, loading: false, error },
+        )
+      })
+    })
+
+    return () => {
+      unsubscribe()
+      controller?.abort()
+    }
   })
 
   function loadMore() {
-    const { cursor, hasMore, loading } = $feed.get()
-    if (hasMore && !loading) loadPage(cursor)
+    const { hasMore, loading } = $feed.get()
+    if (hasMore && !loading) $cursor.set($cursor.get() + 1)
   }
 
-  return { $feed, loadMore }
+  return { $cursor, $feed, loadMore }
 }
 
-const $feed = createFeedResource<Article>((cursor, signal) =>
-  fetch(\`/api/articles?cursor=\${cursor ?? ""}\`, { signal }).then((r) => r.json()),
+const { $feed, loadMore } = createFeedResource<Article>((cursor, signal) =>
+  fetch(\`/api/articles?page=\${cursor}\`, { signal }).then((r) => r.json()),
 )`;
 
 const reactiveParamsSnippet = `type ImageParams = {
@@ -436,17 +435,18 @@ $home.listen((state) => {
             Infinite scroll paginado
           </h3>
           <p class="mb-3 text-sm text-stone-600">
-            <code>$feed</code>: una lista que acumula items página a página,
-            retomando desde el cursor de la última.
+            <code>$cursor</code> guarda la página; <code>$feed</code>{" "}
+            se subscribe a <code>$cursor</code> al montarse y acumula cada respuesta
+            en vez de reemplazarla.
           </p>
           <div class="flex flex-wrap gap-1.5">
             <span
               class="rounded-full bg-stone-100 px-2 py-0.5 text-[11px] font-medium text-stone-600"
-              ><code>FeedState&lt;T&gt;</code></span
+              >dos stores separados</span
             >
             <span
               class="rounded-full bg-stone-100 px-2 py-0.5 text-[11px] font-medium text-stone-600"
-              >cursor</span
+              ><code>subscribe()</code> dentro de onMount</span
             >
             <span
               class="rounded-full bg-stone-100 px-2 py-0.5 text-[11px] font-medium text-stone-600"
@@ -454,7 +454,7 @@ $home.listen((state) => {
             >
             <span
               class="rounded-full bg-stone-100 px-2 py-0.5 text-[11px] font-medium text-stone-600"
-              ><code>onMount</code> condicional</span
+              >acumulación, no reemplazo</span
             >
           </div>
         </a>
@@ -672,16 +672,20 @@ $home.listen((state) => {
                 <a
                   href="#infinite-scroll"
                   class="font-medium text-stone-900 underline"
-                  ><code>FeedState&lt;T&gt;</code></a
+                  ><code>$cursor</code> / <code>$feed</code></a
                 >
               </td>
               <td class="px-4 py-3 align-top">
-                <code>{"{"} items, cursor, hasMore, loading, error {"}"}</code>
+                <code>atom(number) + onMount(subscribe)</code>
               </td>
               <td class="px-4 py-3 align-top">
-                Variante incremental para listas paginadas: cada página se
-                concatena en vez de reemplazar el valor, y el{" "}
-                <code>cursor</code> es el state que permite continuar la paginación.
+                Mismo patrón que <code>$params</code>/<code>$search</code>,
+                aplicado a paginación: <code>$cursor</code> guarda la página, <code
+                  >$feed</code
+                > se <code>subscribe()</code> a ella al montarse. La diferencia es
+                que la respuesta se acumula (<code
+                  >[...prev.items, ...page.items]</code
+                >) en vez de reemplazar el valor.
               </td>
             </tr>
             <tr>
@@ -867,28 +871,37 @@ $home.listen((state) => {
 
     <section id="infinite-scroll" class="mb-12">
       <h2 class="text-xl font-semibold text-stone-900 mb-3">
-        Infinite scroll: un store incremental
+        Infinite scroll: el mismo patrón, con un store que acumula
       </h2>
       <p class="text-stone-600 leading-relaxed mb-4">
-        Una lista paginada tampoco encaja en <code>Resource&lt;T&gt;</code>{" "}
-        tal cual: cada página no reemplaza el estado, lo <strong>acumula</strong
-        >. El "state para continuar la paginación" es el <code>cursor</code> que
-        trae cada respuesta — no un número de página que vos llevas aparte, sino
-        el que el servidor te devuelve para pedir la siguiente tanda.
+        Funciona igual que <code>$params</code>/<code>$search</code>: dos stores
+        separados. <code>$cursor</code> no sabe nada de fetch — solo guarda qué página
+        toca pedir. <code>$feed</code> es el único con{" "}
+        <code>onMount</code>, y al montarse se <code>subscribe()</code> a{" "}
+        <code>$cursor</code>. La única diferencia real es qué hace con la
+        respuesta: en vez de <em>reemplazar</em> el valor, lo{" "}
+        <strong>acumula</strong> (<code>[...prev.items, ...page.items]</code>).
       </p>
       <Code code={infiniteScrollSnippet} lang="ts" theme="github-dark" />
       <p class="text-stone-600 leading-relaxed mt-3">
-        Dos detalles que distinguen este store de los anteriores: primero, cada
-        página se concatena (<code>[...prev.items, ...page.items]</code>) en vez
-        de reemplazar el valor completo. Segundo, <code>onMount</code> solo pide
-        la primera página <em>si todavía no hay items</em> — así un remount rápido
-        (por ejemplo, volver a una lista que ya habías scrolleado) no descarta el
-        progreso ya cargado; simplemente retoma. <code>onUnmount</code> sigue cancelando
-        la página en curso con <code>AbortController</code>, igual que en el
-        ejemplo de arriba, pero sin tocar los items ya acumulados. La demo
-        simula un feed de 20 artículos en 4 páginas: móntala y desplázate dentro
-        de{" "}
-        <code>$feed</code> para ver la carga automática, o usa "Cargar más" directamente.
+        Igual que en <code>$search</code>, <code>subscribe()</code> (no{" "}
+        <code>listen()</code>) hace que la primera página salga de inmediato al
+        montar, con el <code>$cursor</code> inicial (0). Pero acá hay un detalle
+        nuevo: un remount rápido vuelve a disparar el callback con el <em
+          >mismo</em
+        >
+        <code>$cursor</code> de la última vez (porque{" "}
+        <code>$cursor</code> no se resetea entre mounts), y sin cuidado eso repetiría
+        la última página y duplicaría items. El guard{" "}
+        <code>if (cursor === lastFetchedCursor) return</code> es lo que evita eso
+        — el equivalente de "si ya tengo esta página, no la vuelvas a pedir". <code
+          >loadMore()</code
+        > simplemente hace{" "}
+        <code>$cursor.set($cursor.get() + 1)</code>: cambiar el cursor es lo
+        único que hace falta para que <code>$feed</code> reaccione y pida la siguiente
+        tanda. La demo simula un feed de 20 artículos en 4 páginas: móntala y desplázate
+        dentro de <code>$feed</code> para ver la carga automática, o usa "Cargar
+        más" directamente.
       </p>
     </section>
 

--- a/src/pages/my-state-pattern.astro
+++ b/src/pages/my-state-pattern.astro
@@ -106,6 +106,34 @@ const $session = createResource((signal) =>
   fetch('/api/session', { signal }).then((r) => r.json()),
 )`;
 
+const sseSnippet = `function createLiveResource<T>(
+  connect: (
+    onMessage: (data: T) => void,
+    onError: (error: unknown) => void,
+  ) => () => void,
+) {
+  const $resource = atom<Resource<T>>([true, null, null])
+
+  onMount($resource, () => {
+    const close = connect(
+      (data) => $resource.set([false, null, data]),
+      (error) => $resource.set([false, error, null]),
+    )
+
+    // onUnmount: cierra la conexión, no descarta una respuesta puntual
+    return () => close()
+  })
+
+  return $resource
+}
+
+const $liveMetrics = createLiveResource<Metrics>((onMessage, onError) => {
+  const source = new EventSource('/api/metrics/stream')
+  source.onmessage = (event) => onMessage(JSON.parse(event.data))
+  source.onerror = (event) => onError(event)
+  return () => source.close()
+})`;
+
 const reactSnippet = `import { useStore } from '@nanostores/react'
 
 function useHome() {
@@ -213,6 +241,10 @@ $home.listen((state) => {
         ver el <code>onMount</code> disparar los fetch, fuerza un error en algún
         recurso, o desmóntalo para ver el <code>onUnmount</code> abortando el fetch
         en curso con <code>AbortController</code> (mira el registro de actividad).
+        También incluye <code>$liveMetrics</code>, un recurso que simula un{" "}
+        <code>EventSource</code> (SSE): en vez de resolver una vez, empuja mensajes
+        mientras está montado, y <code>onUnmount</code> cierra la conexión en vez
+        de abortar un fetch puntual.
       </p>
       <MyStateDemo client:load />
     </section>
@@ -273,6 +305,33 @@ $home.listen((state) => {
         el de un reintento posterior). La demo de más arriba implementa exactamente
         este patrón — desmóntala mientras un recurso está cargando y revisa el registro
         de actividad.
+      </p>
+    </section>
+
+    <section class="mb-12">
+      <h2 class="text-xl font-semibold text-stone-900 mb-3">
+        Streaming con SSE: un recurso que no se resuelve una sola vez
+      </h2>
+      <p class="text-stone-600 leading-relaxed mb-4">
+        El contrato <code>onMount</code>/<code>onUnmount</code> no es exclusivo de
+        <code>fetch</code>. Sirve para cualquier fuente que necesite abrirse al
+        montar y cerrarse al desmontar: un{" "}
+        <code>EventSource</code> (Server-Sent Events) es el ejemplo más directo.
+        La diferencia con un recurso normal es que{" "}
+        <code>$resource.set(...)</code> se llama muchas veces — una por mensaje —
+        en vez de una sola vez al resolver una promesa.
+      </p>
+      <Code code={sseSnippet} lang="ts" theme="github-dark" />
+      <p class="text-stone-600 leading-relaxed mt-3">
+        Aquí <code>onUnmount</code> no aborta una petición puntual, cierra una conexión
+        de larga duración con <code>source.close()</code>. Sin ese cleanup, cada
+        vez que la página se desmonta y se vuelve a montar (por ejemplo, al
+        navegar) quedaría una conexión SSE abierta escuchando eventos que nadie
+        va a leer — un leak silencioso y fácil de pasar por alto. La demo de
+        arriba simula esto con{" "}
+        <code>$liveMetrics</code>: móntala para ver los mensajes llegar cada
+        ~700ms, fuerza un corte de conexión, o desmóntala y revisa el registro
+        de actividad para confirmar el <code>source.close()</code>.
       </p>
     </section>
 


### PR DESCRIPTION
Adds /my-state-pattern with the tuple/t() helper explanation, both
monolithic and atomized code variants from the pattern's article, and
a live React + nanostores demo that runs the real onMount/onStop
lifecycle so visitors can mount, force errors, retry, and unmount the
simulated resources.